### PR TITLE
feat: add unit test for non-existent function call

### DIFF
--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -16,7 +16,11 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
+import pytest
+from eth_utils import to_checksum_address
+
 from web3 import Web3
+from web3.exceptions import ContractLogicError
 from web3.middleware import geth_poa_middleware
 from web3.datastructures import AttributeDict
 
@@ -474,3 +478,33 @@ class TestE2E:
 
         # Assertion
         assert txn_receipt["status"] == 0
+
+    # <Error_4>
+    # Occur REVERT
+    # Calls to non-existent attribute cause revert.
+    def test_error_4(self):
+        contract_json = ContractUtils.get_contract_json()
+
+        not_deployed_func = {
+            "inputs": [],
+            "name": "notExistAttribute",
+            "outputs": [{
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }],
+            "stateMutability": "view",
+            "type": "function"
+        }
+        # Inject invalid contract function to ABI
+        contract_json["abi"].append(not_deployed_func)
+
+        # Create contract object with invalid ABI
+        contract_with_invalid_abi = web3.eth.contract(
+            address=to_checksum_address(DEPLOYED_CONTRACT_ADDRESS),
+            abi=contract_json['abi'],
+        )
+        _function = getattr(contract_with_invalid_abi.functions, "notExistAttribute")
+        args = []
+        with pytest.raises(ContractLogicError):
+            _ = _function(*args).call()


### PR DESCRIPTION

- From v2.0, calls of non-existent function/attribute cause revert with `ContractLogicError` so added a unittest.
  - Up to version 1.3, `web3.exceptions.BadFunctionCallOutput` raises like following.

> FAILED tests/e2e_test.py::TestE2E::test_error_4 - web3.exceptions.BadFunctionCallOutput: Could not decode contract function call notExistAttribute return data b'' for output_types ['address'] 