### PR TITLE
Bump web3py & Fix unit test error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: format isort black test
+
+install:
+	pip install -r tests/requirements.txt
+
+format: isort black
+
+isort:
+	isort .
+
+black:
+	black .
+
+test:
+	pytest tests/ ${ARG}

--- a/ibet-for-fin-network/general/monitoring/monitor_block_sync.py
+++ b/ibet-for-fin-network/general/monitoring/monitor_block_sync.py
@@ -17,34 +17,41 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 import logging
-from logging.config import dictConfig
 import os
 import sys
 import time
+from logging.config import dictConfig
 
 from requests.exceptions import ConnectionError
 from web3 import Web3
 
 BLOCK_SYNC_MONITORING_INTERVAL = os.environ.get("BLOCK_SYNC_MONITORING_INTERVAL") or 30
-MINIMUM_INCREMENTAL_NUMBER = os.environ.get("BLOCK_SYNC_MONITORING_MINIMUM_INCREMENTAL_NUMBER") or 1
+MINIMUM_INCREMENTAL_NUMBER = (
+    os.environ.get("BLOCK_SYNC_MONITORING_MINIMUM_INCREMENTAL_NUMBER") or 1
+)
 
 web3 = Web3(Web3.HTTPProvider("http://localhost:8545"))
 
-LOG_CONFIG = ({
+LOG_CONFIG = {
     "version": 1,
-    "handlers": {"console": {
-        "class": "logging.StreamHandler",
-        "stream": sys.stdout,
-    }},
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "stream": sys.stdout,
+        }
+    },
     "loggers": {
         "monitor": {
-            "handlers": ["console", ],
+            "handlers": [
+                "console",
+            ],
             "propagate": False,
-        }},
+        }
+    },
     "root": {
         "level": "INFO",
-    }
-})
+    },
+}
 dictConfig(LOG_CONFIG)
 log_fmt = "%(levelname)s [%(asctime)s|MONITOR-BLOCK-SYNC] %(message)s"
 logging.basicConfig(format=log_fmt)
@@ -58,7 +65,9 @@ def monitor_block_sync(start_block_number):
     """
     try:
         latest_block_number = web3.eth.blockNumber
-        if latest_block_number - start_block_number > MINIMUM_INCREMENTAL_NUMBER:  # Normal
+        if (
+            latest_block_number - start_block_number > MINIMUM_INCREMENTAL_NUMBER
+        ):  # Normal
             logging.info(
                 f"Blocks are successfully synchronized: "
                 f"start={start_block_number}, "
@@ -74,7 +83,9 @@ def monitor_block_sync(start_block_number):
     except ConnectionError:
         logging.warning("Unable to connect to node")
     except Exception as err:
-        logging.exception("An exception occurred while monitoring block synchronization: ", err)
+        logging.exception(
+            "An exception occurred while monitoring block synchronization: ", err
+        )
     finally:
         return start_block_number
 

--- a/ibet-network/general/monitoring/monitor_block_sync.py
+++ b/ibet-network/general/monitoring/monitor_block_sync.py
@@ -17,34 +17,41 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 import logging
-from logging.config import dictConfig
 import os
 import sys
 import time
+from logging.config import dictConfig
 
 from requests.exceptions import ConnectionError
 from web3 import Web3
 
 BLOCK_SYNC_MONITORING_INTERVAL = os.environ.get("BLOCK_SYNC_MONITORING_INTERVAL") or 30
-MINIMUM_INCREMENTAL_NUMBER = os.environ.get("BLOCK_SYNC_MONITORING_MINIMUM_INCREMENTAL_NUMBER") or 1
+MINIMUM_INCREMENTAL_NUMBER = (
+    os.environ.get("BLOCK_SYNC_MONITORING_MINIMUM_INCREMENTAL_NUMBER") or 1
+)
 
 web3 = Web3(Web3.HTTPProvider("http://localhost:8545"))
 
-LOG_CONFIG = ({
+LOG_CONFIG = {
     "version": 1,
-    "handlers": {"console": {
-        "class": "logging.StreamHandler",
-        "stream": sys.stdout,
-    }},
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "stream": sys.stdout,
+        }
+    },
     "loggers": {
         "monitor": {
-            "handlers": ["console", ],
+            "handlers": [
+                "console",
+            ],
             "propagate": False,
-        }},
+        }
+    },
     "root": {
         "level": "INFO",
-    }
-})
+    },
+}
 dictConfig(LOG_CONFIG)
 log_fmt = "%(levelname)s [%(asctime)s|MONITOR-BLOCK-SYNC] %(message)s"
 logging.basicConfig(format=log_fmt)
@@ -58,7 +65,9 @@ def monitor_block_sync(start_block_number):
     """
     try:
         latest_block_number = web3.eth.blockNumber
-        if latest_block_number - start_block_number > MINIMUM_INCREMENTAL_NUMBER:  # Normal
+        if (
+            latest_block_number - start_block_number > MINIMUM_INCREMENTAL_NUMBER
+        ):  # Normal
             logging.info(
                 f"Blocks are successfully synchronized: "
                 f"start={start_block_number}, "
@@ -74,7 +83,9 @@ def monitor_block_sync(start_block_number):
     except ConnectionError:
         logging.warning("Unable to connect to node")
     except Exception as err:
-        logging.exception("An exception occurred while monitoring block synchronization: ", err)
+        logging.exception(
+            "An exception occurred while monitoring block synchronization: ", err
+        )
     finally:
         return start_block_number
 

--- a/local-network/general/monitoring/monitor_block_sync.py
+++ b/local-network/general/monitoring/monitor_block_sync.py
@@ -17,34 +17,41 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 import logging
-from logging.config import dictConfig
 import os
 import sys
 import time
+from logging.config import dictConfig
 
 from requests.exceptions import ConnectionError
 from web3 import Web3
 
 BLOCK_SYNC_MONITORING_INTERVAL = os.environ.get("BLOCK_SYNC_MONITORING_INTERVAL") or 30
-MINIMUM_INCREMENTAL_NUMBER = os.environ.get("BLOCK_SYNC_MONITORING_MINIMUM_INCREMENTAL_NUMBER") or 1
+MINIMUM_INCREMENTAL_NUMBER = (
+    os.environ.get("BLOCK_SYNC_MONITORING_MINIMUM_INCREMENTAL_NUMBER") or 1
+)
 
 web3 = Web3(Web3.HTTPProvider("http://localhost:8545"))
 
-LOG_CONFIG = ({
+LOG_CONFIG = {
     "version": 1,
-    "handlers": {"console": {
-        "class": "logging.StreamHandler",
-        "stream": sys.stdout,
-    }},
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "stream": sys.stdout,
+        }
+    },
     "loggers": {
         "monitor": {
-            "handlers": ["console", ],
+            "handlers": [
+                "console",
+            ],
             "propagate": False,
-        }},
+        }
+    },
     "root": {
         "level": "INFO",
-    }
-})
+    },
+}
 dictConfig(LOG_CONFIG)
 log_fmt = "%(levelname)s [%(asctime)s|MONITOR-BLOCK-SYNC] %(message)s"
 logging.basicConfig(format=log_fmt)
@@ -58,7 +65,9 @@ def monitor_block_sync(start_block_number):
     """
     try:
         latest_block_number = web3.eth.blockNumber
-        if latest_block_number - start_block_number > MINIMUM_INCREMENTAL_NUMBER:  # Normal
+        if (
+            latest_block_number - start_block_number > MINIMUM_INCREMENTAL_NUMBER
+        ):  # Normal
             logging.info(
                 f"Blocks are successfully synchronized: "
                 f"start={start_block_number}, "
@@ -74,7 +83,9 @@ def monitor_block_sync(start_block_number):
     except ConnectionError:
         logging.warning("Unable to connect to node")
     except Exception as err:
-        logging.exception("An exception occurred while monitoring block synchronization: ", err)
+        logging.exception(
+            "An exception occurred while monitoring block synchronization: ", err
+        )
     finally:
         return start_block_number
 

--- a/test-network/general/monitoring/monitor_block_sync.py
+++ b/test-network/general/monitoring/monitor_block_sync.py
@@ -17,34 +17,41 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 import logging
-from logging.config import dictConfig
 import os
 import sys
 import time
+from logging.config import dictConfig
 
 from requests.exceptions import ConnectionError
 from web3 import Web3
 
 BLOCK_SYNC_MONITORING_INTERVAL = os.environ.get("BLOCK_SYNC_MONITORING_INTERVAL") or 30
-MINIMUM_INCREMENTAL_NUMBER = os.environ.get("BLOCK_SYNC_MONITORING_MINIMUM_INCREMENTAL_NUMBER") or 1
+MINIMUM_INCREMENTAL_NUMBER = (
+    os.environ.get("BLOCK_SYNC_MONITORING_MINIMUM_INCREMENTAL_NUMBER") or 1
+)
 
 web3 = Web3(Web3.HTTPProvider("http://localhost:8545"))
 
-LOG_CONFIG = ({
+LOG_CONFIG = {
     "version": 1,
-    "handlers": {"console": {
-        "class": "logging.StreamHandler",
-        "stream": sys.stdout,
-    }},
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "stream": sys.stdout,
+        }
+    },
     "loggers": {
         "monitor": {
-            "handlers": ["console", ],
+            "handlers": [
+                "console",
+            ],
             "propagate": False,
-        }},
+        }
+    },
     "root": {
         "level": "INFO",
-    }
-})
+    },
+}
 dictConfig(LOG_CONFIG)
 log_fmt = "%(levelname)s [%(asctime)s|MONITOR-BLOCK-SYNC] %(message)s"
 logging.basicConfig(format=log_fmt)
@@ -58,7 +65,9 @@ def monitor_block_sync(start_block_number):
     """
     try:
         latest_block_number = web3.eth.blockNumber
-        if latest_block_number - start_block_number > MINIMUM_INCREMENTAL_NUMBER:  # Normal
+        if (
+            latest_block_number - start_block_number > MINIMUM_INCREMENTAL_NUMBER
+        ):  # Normal
             logging.info(
                 f"Blocks are successfully synchronized: "
                 f"start={start_block_number}, "
@@ -74,7 +83,9 @@ def monitor_block_sync(start_block_number):
     except ConnectionError:
         logging.warning("Unable to connect to node")
     except Exception as err:
-        logging.exception("An exception occurred while monitoring block synchronization: ", err)
+        logging.exception(
+            "An exception occurred while monitoring block synchronization: ", err
+        )
     finally:
         return start_block_number
 

--- a/tests/compile.py
+++ b/tests/compile.py
@@ -22,14 +22,10 @@ import sys
 
 import solcx
 
-path = os.path.join(os.path.dirname(__file__), '../')
+path = os.path.join(os.path.dirname(__file__), "../")
 sys.path.append(path)
 
-from tests.config import (
-    SOLC_VERSION_PRAGMA,
-    CONTRACT_PATH,
-    CONTRACT_NAME
-)
+from tests.config import CONTRACT_NAME, CONTRACT_PATH, SOLC_VERSION_PRAGMA
 
 # Install Solc
 solcx.install_solc_pragma(SOLC_VERSION_PRAGMA)
@@ -39,29 +35,25 @@ version = solcx.get_installed_solc_versions()[0]
 spec = {
     "language": "Solidity",
     "sources": {
-        f"{CONTRACT_NAME}.sol": {
-            "urls": [f"{CONTRACT_PATH}/{CONTRACT_NAME}.sol"]
-        }
+        f"{CONTRACT_NAME}.sol": {"urls": [f"{CONTRACT_PATH}/{CONTRACT_NAME}.sol"]}
     },
     "settings": {
         "evmVersion": "berlin",
-        "optimizer": {
-            "enabled": True,
-            "runs": 200
-        },
+        "optimizer": {"enabled": True, "runs": 200},
         "outputSelection": {
             "*": {
                 "*": [
-                    "abi", "evm.bytecode.object", "evm.deployedBytecode.object",
+                    "abi",
+                    "evm.bytecode.object",
+                    "evm.deployedBytecode.object",
                 ]
             }
-        }
-    }
+        },
+    },
 }
 contract_json = solcx.compile_standard(
-    spec,
-    allow_paths=[os.path.dirname(os.path.abspath(__file__))],
-    solc_version=version)
+    spec, allow_paths=[os.path.dirname(os.path.abspath(__file__))], solc_version=version
+)
 
 # Output File
 contract_json = contract_json["contracts"][f"{CONTRACT_NAME}.sol"][CONTRACT_NAME]

--- a/tests/config.py
+++ b/tests/config.py
@@ -26,8 +26,10 @@ ACCOUNT_NAME = "test_user"
 ACCOUNT_PASSWORD = "password"
 
 # Environment variables
-SOLC_VERSION_PRAGMA = os.environ.get('SOLC_VERSION_PRAGMA') or "^0.8.0"
+SOLC_VERSION_PRAGMA = os.environ.get("SOLC_VERSION_PRAGMA") or "^0.8.0"
 WEB3_HTTP_PROVIDER = os.environ.get("WEB3_HTTP_PROVIDER") or "http://localhost:8545"
 CHAIN_ID = int(os.environ.get("CHAIN_ID")) if os.environ.get("CHAIN_ID") else 2017
-TX_GAS_LIMIT = int(os.environ.get("TX_GAS_LIMIT")) if os.environ.get("TX_GAS_LIMIT") else 6000000
+TX_GAS_LIMIT = (
+    int(os.environ.get("TX_GAS_LIMIT")) if os.environ.get("TX_GAS_LIMIT") else 6000000
+)
 DEPLOYED_CONTRACT_ADDRESS = os.environ.get("DEPLOYED_CONTRACT_ADDRESS") or ZERO_ADDRESS

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,12 +16,14 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
+import logging
 import os
 import sys
-import logging
-import pytest
 
-path = os.path.join(os.path.dirname(__file__), '../')
+import pytest
+from web3 import Web3
+
+path = os.path.join(os.path.dirname(__file__), "../")
 sys.path.append(path)
 
 from tests.util import ContractUtils
@@ -38,7 +40,7 @@ def contract():
         "test text",
         1,
         2,
-        b'abc'
+        b"abc",
     ]
     contract_address, _, _ = ContractUtils.deploy_contract(args)
     return ContractUtils.get_contract(contract_address)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,6 @@ import os
 import sys
 
 import pytest
-from web3 import Web3
 
 path = os.path.join(os.path.dirname(__file__), "../")
 sys.path.append(path)

--- a/tests/deploy.py
+++ b/tests/deploy.py
@@ -19,17 +19,11 @@ SPDX-License-Identifier: Apache-2.0
 import os
 import sys
 
-path = os.path.join(os.path.dirname(__file__), '../')
+path = os.path.join(os.path.dirname(__file__), "../")
 sys.path.append(path)
 
-from tests.config import (
-    CHAIN_ID,
-    TX_GAS_LIMIT
-)
-from tests.util import (
-    TestAccount,
-    ContractUtils
-)
+from tests.config import CHAIN_ID, TX_GAS_LIMIT
+from tests.util import ContractUtils, TestAccount
 
 # Deploy
 args = [
@@ -38,7 +32,7 @@ args = [
     "test text",
     1,
     2,
-    b'0123456789abcdefghijklmnopqrstuv'
+    b"0123456789abcdefghijklmnopqrstuv",
 ]
 contract_address, _, _ = ContractUtils.deploy_contract(args)
 
@@ -50,31 +44,27 @@ args = [
     "test text2",
     4,
     8,
-    b'456789abcdefghijklmnopqrstuvwxyz'
+    b"456789abcdefghijklmnopqrstuvwxyz",
 ]
-tx = contract.functions.setItem3(*args).buildTransaction(
+tx = contract.functions.setItem3(*args).build_transaction(
     transaction={
         "chainId": CHAIN_ID,
         "from": TestAccount.address,
         "gas": TX_GAS_LIMIT,
-        "gasPrice": 0
+        "gasPrice": 0,
     }
 )
 _, txn_receipt = ContractUtils.send_transaction(
-    transaction=tx,
-    private_key=TestAccount.private_key
+    transaction=tx, private_key=TestAccount.private_key
 )
-tx = contract.functions.setOptionalItem(txn_receipt["blockNumber"]).buildTransaction(
+tx = contract.functions.setOptionalItem(txn_receipt["blockNumber"]).build_transaction(
     transaction={
         "chainId": CHAIN_ID,
         "from": TestAccount.address,
         "gas": TX_GAS_LIMIT,
-        "gasPrice": 0
+        "gasPrice": 0,
     }
 )
-ContractUtils.send_transaction(
-    transaction=tx,
-    private_key=TestAccount.private_key
-)
+ContractUtils.send_transaction(transaction=tx, private_key=TestAccount.private_key)
 
 print(f"DEPLOYED_CONTRACT_ADDRESS={contract_address}")

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -20,7 +20,7 @@ import pytest
 from eth_utils import to_checksum_address
 
 from web3 import Web3
-from web3.exceptions import BadFunctionCallOutput
+from web3.exceptions import ContractLogicError
 from web3.middleware import geth_poa_middleware
 from web3.datastructures import AttributeDict
 
@@ -506,5 +506,5 @@ class TestE2E:
         )
         _function = getattr(contract_with_invalid_abi.functions, "notExistAttribute")
         args = []
-        with pytest.raises(BadFunctionCallOutput):
+        with pytest.raises(ContractLogicError):
             _ = _function(*args).call()

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -18,23 +18,19 @@ SPDX-License-Identifier: Apache-2.0
 """
 import pytest
 from eth_utils import to_checksum_address
-
 from web3 import Web3
+from web3.datastructures import AttributeDict
 from web3.exceptions import ContractLogicError
 from web3.middleware import geth_poa_middleware
-from web3.datastructures import AttributeDict
 
 from tests.config import (
-    ZERO_ADDRESS,
-    WEB3_HTTP_PROVIDER,
     CHAIN_ID,
+    DEPLOYED_CONTRACT_ADDRESS,
     TX_GAS_LIMIT,
-    DEPLOYED_CONTRACT_ADDRESS
+    WEB3_HTTP_PROVIDER,
+    ZERO_ADDRESS,
 )
-from tests.util import (
-    TestAccount,
-    ContractUtils
-)
+from tests.util import ContractUtils, TestAccount
 
 web3 = Web3(Web3.HTTPProvider(WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(geth_poa_middleware, layer=0)
@@ -56,7 +52,6 @@ web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 # - eth_sendTransaction
 # - eth_getCode
 class TestE2E:
-
     ###########################################################################
     # Normal Case
     ###########################################################################
@@ -68,25 +63,30 @@ class TestE2E:
     # - eth_getTransactionReceipt
     # - eth_call
     def test_normal_1_1(self):
-
         args = [
             True,
             "0x0123456789abcDEF0123456789abCDef01234567",
             "test text",
             1,
             2,
-            b'0123456789abcdefghijklmnopqrstuv'
+            b"0123456789abcdefghijklmnopqrstuv",
         ]
         contract_address, _, _ = ContractUtils.deploy_contract(args)
         contract = ContractUtils.get_contract(contract_address)
 
         # Assertion
         assert contract.functions.item1_bool().call() is True
-        assert contract.functions.item1_address().call() == "0x0123456789abcDEF0123456789abCDef01234567"
+        assert (
+            contract.functions.item1_address().call()
+            == "0x0123456789abcDEF0123456789abCDef01234567"
+        )
         assert contract.functions.item1_string().call() == "test text"
         assert contract.functions.item1_uint().call() == 1
         assert contract.functions.item1_int().call() == 2
-        assert contract.functions.item1_bytes().call() == b'0123456789abcdefghijklmnopqrstuv'
+        assert (
+            contract.functions.item1_bytes().call()
+            == b"0123456789abcdefghijklmnopqrstuv"
+        )
 
     # <Normal_1_2>
     # deploy setting(deployed contract)
@@ -98,11 +98,17 @@ class TestE2E:
         # Assertion
         contract = ContractUtils.get_contract(DEPLOYED_CONTRACT_ADDRESS)
         assert contract.functions.item3_bool().call() is False
-        assert contract.functions.item3_address().call() == "0x0123456789ABCDeF0123456789aBcdEF01234568"
+        assert (
+            contract.functions.item3_address().call()
+            == "0x0123456789ABCDeF0123456789aBcdEF01234568"
+        )
         assert contract.functions.item3_string().call() == "test text2"
         assert contract.functions.item3_uint().call() == 4
         assert contract.functions.item3_int().call() == 8
-        assert contract.functions.item3_bytes().call() == b'456789abcdefghijklmnopqrstuvwxyz'
+        assert (
+            contract.functions.item3_bytes().call()
+            == b"456789abcdefghijklmnopqrstuvwxyz"
+        )
 
     # <Normal_2_1>
     # call setter/getter function
@@ -111,32 +117,37 @@ class TestE2E:
     # - eth_getTransactionReceipt
     # - eth_call
     def test_normal_2_1(self, contract):
-
         args = [
             False,
             "0x0123456789ABCDeF0123456789aBcdEF01234568",
             "test text2",
             4,
             8,
-            b'456789abcdefghijklmnopqrstuvwxyz'
+            b"456789abcdefghijklmnopqrstuvwxyz",
         ]
-        tx = contract.functions.setItem2(*args, 0).buildTransaction(
+        tx = contract.functions.setItem2(*args, 0).build_transaction(
             transaction={
                 "chainId": CHAIN_ID,
                 "from": TestAccount.address,
                 "gas": TX_GAS_LIMIT,
-                "gasPrice": 0
+                "gasPrice": 0,
             }
         )
         ContractUtils.send_transaction(tx, TestAccount.private_key)
 
         # Assertion
         assert contract.functions.item2_bool().call() is False
-        assert contract.functions.item2_address().call() == "0x0123456789ABCDeF0123456789aBcdEF01234568"
+        assert (
+            contract.functions.item2_address().call()
+            == "0x0123456789ABCDeF0123456789aBcdEF01234568"
+        )
         assert contract.functions.item2_string().call() == "test text2"
         assert contract.functions.item2_uint().call() == 4
         assert contract.functions.item2_int().call() == 8
-        assert contract.functions.item2_bytes().call() == b'456789abcdefghijklmnopqrstuvwxyz'
+        assert (
+            contract.functions.item2_bytes().call()
+            == b"456789abcdefghijklmnopqrstuvwxyz"
+        )
         assert contract.functions.getItemsValueSame().call() == 5
 
     # <Normal_2_2>
@@ -159,25 +170,31 @@ class TestE2E:
             "test text2",
             16,
             8,
-            b'456789abcdefghijklmnopqrstuvwxyz'
+            b"456789abcdefghijklmnopqrstuvwxyz",
         ]
-        tx = contract.functions.setItem2(*args, 0).buildTransaction(
+        tx = contract.functions.setItem2(*args, 0).build_transaction(
             transaction={
                 "chainId": CHAIN_ID,
                 "from": TestAccount.address,
                 "gas": TX_GAS_LIMIT,
-                "gasPrice": 0
+                "gasPrice": 0,
             }
         )
         ContractUtils.send_transaction(tx, TestAccount.private_key)
 
         # Assertion
         assert contract.functions.item2_bool().call() is False
-        assert contract.functions.item2_address().call() == "0x0123456789ABCDeF0123456789aBcdEF01234568"
+        assert (
+            contract.functions.item2_address().call()
+            == "0x0123456789ABCDeF0123456789aBcdEF01234568"
+        )
         assert contract.functions.item2_string().call() == "test text2"
         assert contract.functions.item2_uint().call() == 16
         assert contract.functions.item2_int().call() == 8
-        assert contract.functions.item2_bytes().call() == b'456789abcdefghijklmnopqrstuvwxyz'
+        assert (
+            contract.functions.item2_bytes().call()
+            == b"456789abcdefghijklmnopqrstuvwxyz"
+        )
         assert contract.functions.getItemsValueSame().call() == 17
 
     # <Normal_3_1>
@@ -188,29 +205,27 @@ class TestE2E:
     # - eth_getTransactionReceipt
     # - eth_getLogs
     def test_normal_3_1(self, contract):
-
-        block_from = web3.eth.blockNumber
+        block_from = web3.eth.block_number
         args = [
             False,
             "0x0123456789ABCDeF0123456789aBcdEF01234568",
             "test text2",
             4,
             8,
-            b'456789abcdefghijklmnopqrstuvwxyz'
+            b"456789abcdefghijklmnopqrstuvwxyz",
         ]
-        tx = contract.functions.setItem2(*args, 0).buildTransaction(
+        tx = contract.functions.setItem2(*args, 0).build_transaction(
             transaction={
                 "chainId": CHAIN_ID,
                 "from": TestAccount.address,
                 "gas": TX_GAS_LIMIT,
-                "gasPrice": 0
+                "gasPrice": 0,
             }
         )
         ContractUtils.send_transaction(tx, TestAccount.private_key)
-        block_to = web3.eth.blockNumber
-        events = contract.events.SetItem.getLogs(
-            fromBlock=block_from,
-            toBlock=block_to
+        block_to = web3.eth.block_number
+        events = contract.events.SetItem.get_logs(
+            fromBlock=block_from, toBlock=block_to
         )
 
         # Assertion
@@ -222,7 +237,7 @@ class TestE2E:
         assert args["item_string"] == "test text2"
         assert args["item_uint"] == 4
         assert args["item_int"] == 8
-        assert args["item_bytes"] == b'456789abcdefghijklmnopqrstuvwxyz'
+        assert args["item_bytes"] == b"456789abcdefghijklmnopqrstuvwxyz"
 
     # <Normal_3_2>
     # Get events(deployed contract)
@@ -234,9 +249,8 @@ class TestE2E:
 
         contract = ContractUtils.get_contract(DEPLOYED_CONTRACT_ADDRESS)
         block_number = contract.functions.optional_item().call()
-        events = contract.events.SetItem.getLogs(
-            fromBlock=block_number,
-            toBlock=block_number
+        events = contract.events.SetItem.get_logs(
+            fromBlock=block_number, toBlock=block_number
         )
 
         # Assertion
@@ -248,15 +262,14 @@ class TestE2E:
         assert args["item_string"] == "test text2"
         assert args["item_uint"] == 4
         assert args["item_int"] == 8
-        assert args["item_bytes"] == b'456789abcdefghijklmnopqrstuvwxyz'
+        assert args["item_bytes"] == b"456789abcdefghijklmnopqrstuvwxyz"
 
     # <Normal_4>
     # Get block by number
     # - eth_blockNumber
     # - eth_getBlockByNumber
     def test_normal_4(self):
-
-        block_number = web3.eth.blockNumber
+        block_number = web3.eth.block_number
         block = web3.eth.get_block(block_number)
 
         # Assertion
@@ -266,18 +279,20 @@ class TestE2E:
     # Get sync information
     # - eth_syncing
     def test_normal_5(self, contract):
-
         sync = web3.eth.syncing
 
         # Assertion
-        if not isinstance(sync, bool) and not isinstance(sync, dict) and not isinstance(sync, AttributeDict):
+        if (
+            not isinstance(sync, bool)
+            and not isinstance(sync, dict)
+            and not isinstance(sync, AttributeDict)
+        ):
             assert False
 
     # <Normal_6>
     # Get inspected transaction pool
     # - txpool_inspect(Geth API)
     def test_normal_6(self, contract):
-
         txpool = web3.geth.txpool.inspect()
 
         # Assertion
@@ -288,25 +303,20 @@ class TestE2E:
     # Unlock and send transaction
     # - personal_listAccounts(Geth API)
     # - personal_unlockAccounts(Geth API)
-    # - eth_sendTransaction
+    # - eth_send_transaction
     # - eth_getTransactionReceipt
     def test_normal_7(self, contract):
         # Import raw key
         try:
             web3.geth.personal.import_raw_key(
-                TestAccount.private_key,
-                TestAccount.password
+                TestAccount.private_key, TestAccount.password
             )
         except ValueError:
             pass
 
         # Unlock account
         eth_account = web3.geth.personal.list_accounts()[0]
-        web3.geth.personal.unlock_account(
-            eth_account,
-            TestAccount.password,
-            10
-        )
+        web3.geth.personal.unlock_account(eth_account, TestAccount.password, 10)
 
         # Send transaction
         args = [
@@ -315,39 +325,43 @@ class TestE2E:
             "test text2",
             4,
             8,
-            b'456789abcdefghijklmnopqrstuvwxyz'
+            b"456789abcdefghijklmnopqrstuvwxyz",
         ]
-        tx = contract.functions.setItem2(*args, 0).buildTransaction(
+        tx = contract.functions.setItem2(*args, 0).build_transaction(
             transaction={
                 "chainId": CHAIN_ID,
                 "from": eth_account,
                 "gas": TX_GAS_LIMIT,
-                "gasPrice": 0
+                "gasPrice": 0,
             }
         )
-        tx_hash = web3.eth.sendTransaction(tx)
-        txn_receipt = web3.eth.waitForTransactionReceipt(
-            transaction_hash=tx_hash,
-            timeout=10
+        tx_hash = web3.eth.send_transaction(tx)
+        txn_receipt = web3.eth.wait_for_transaction_receipt(
+            transaction_hash=tx_hash, timeout=10
         )
 
         # Assertion
         assert txn_receipt["status"] == 1
         assert contract.functions.item2_bool().call() is False
-        assert contract.functions.item2_address().call() == "0x0123456789ABCDeF0123456789aBcdEF01234568"
+        assert (
+            contract.functions.item2_address().call()
+            == "0x0123456789ABCDeF0123456789aBcdEF01234568"
+        )
         assert contract.functions.item2_string().call() == "test text2"
         assert contract.functions.item2_uint().call() == 4
         assert contract.functions.item2_int().call() == 8
-        assert contract.functions.item2_bytes().call() == b'456789abcdefghijklmnopqrstuvwxyz'
+        assert (
+            contract.functions.item2_bytes().call()
+            == b"456789abcdefghijklmnopqrstuvwxyz"
+        )
         assert contract.functions.getItemsValueSame().call() == 5
 
     # <Normal_8_1>
     # Get bytecode(contract address)
     # - eth_getCode
     def test_normal_8_1(self, contract):
-
         # Get bytecode
-        bytecode = web3.eth.getCode(contract.address)
+        bytecode = web3.eth.get_code(contract.address)
 
         # Assertion
         contract_json = ContractUtils.get_contract_json()
@@ -357,9 +371,8 @@ class TestE2E:
     # Get bytecode(EOA address)
     # - eth_getCode
     def test_normal_8_2(self, contract):
-
         # Get bytecode
-        bytecode = web3.eth.getCode(TestAccount.address)
+        bytecode = web3.eth.get_code(TestAccount.address)
 
         # Assertion
         assert bytecode.hex() == "0x"
@@ -372,7 +385,6 @@ class TestE2E:
     # Occur REVERT
     # assert error
     def test_error_1(self, contract):
-
         err_flg = 1
         args = [
             False,
@@ -380,26 +392,24 @@ class TestE2E:
             "test text2",
             4,
             8,
-            b'456789abcdefghijklmnopqrstuvwxyz'
+            b"456789abcdefghijklmnopqrstuvwxyz",
         ]
-        tx = contract.functions.setItem2(*args, err_flg).buildTransaction(
+        tx = contract.functions.setItem2(*args, err_flg).build_transaction(
             transaction={
                 "chainId": CHAIN_ID,
                 "from": TestAccount.address,
                 "gas": TX_GAS_LIMIT,
-                "gasPrice": 0
+                "gasPrice": 0,
             }
         )
-        nonce = web3.eth.getTransactionCount(TestAccount.address)
+        nonce = web3.eth.get_transaction_count(TestAccount.address)
         tx["nonce"] = nonce
         signed_tx = web3.eth.account.sign_transaction(
-            transaction_dict=tx,
-            private_key=TestAccount.private_key
+            transaction_dict=tx, private_key=TestAccount.private_key
         )
-        tx_hash = web3.eth.sendRawTransaction(signed_tx.rawTransaction.hex())
-        txn_receipt = web3.eth.waitForTransactionReceipt(
-            transaction_hash=tx_hash,
-            timeout=10
+        tx_hash = web3.eth.send_raw_transaction(signed_tx.rawTransaction.hex())
+        txn_receipt = web3.eth.wait_for_transaction_receipt(
+            transaction_hash=tx_hash, timeout=10
         )
 
         # Assertion
@@ -409,7 +419,6 @@ class TestE2E:
     # Occur REVERT
     # require error
     def test_error_2(self, contract):
-
         err_flg = 2
         args = [
             False,
@@ -417,26 +426,24 @@ class TestE2E:
             "test text2",
             4,
             8,
-            b'456789abcdefghijklmnopqrstuvwxyz'
+            b"456789abcdefghijklmnopqrstuvwxyz",
         ]
-        tx = contract.functions.setItem2(*args, err_flg).buildTransaction(
+        tx = contract.functions.setItem2(*args, err_flg).build_transaction(
             transaction={
                 "chainId": CHAIN_ID,
                 "from": TestAccount.address,
                 "gas": TX_GAS_LIMIT,
-                "gasPrice": 0
+                "gasPrice": 0,
             }
         )
-        nonce = web3.eth.getTransactionCount(TestAccount.address)
+        nonce = web3.eth.get_transaction_count(TestAccount.address)
         tx["nonce"] = nonce
         signed_tx = web3.eth.account.sign_transaction(
-            transaction_dict=tx,
-            private_key=TestAccount.private_key
+            transaction_dict=tx, private_key=TestAccount.private_key
         )
-        tx_hash = web3.eth.sendRawTransaction(signed_tx.rawTransaction.hex())
-        txn_receipt = web3.eth.waitForTransactionReceipt(
-            transaction_hash=tx_hash,
-            timeout=10
+        tx_hash = web3.eth.send_raw_transaction(signed_tx.rawTransaction.hex())
+        txn_receipt = web3.eth.wait_for_transaction_receipt(
+            transaction_hash=tx_hash, timeout=10
         )
 
         # Assertion
@@ -446,7 +453,6 @@ class TestE2E:
     # Occur REVERT
     # reverted
     def test_error_3(self, contract):
-
         err_flg = 3
         args = [
             False,
@@ -454,26 +460,24 @@ class TestE2E:
             "test text2",
             4,
             8,
-            b'456789abcdefghijklmnopqrstuvwxyz'
+            b"456789abcdefghijklmnopqrstuvwxyz",
         ]
-        tx = contract.functions.setItem2(*args, err_flg).buildTransaction(
+        tx = contract.functions.setItem2(*args, err_flg).build_transaction(
             transaction={
                 "chainId": CHAIN_ID,
                 "from": TestAccount.address,
                 "gas": TX_GAS_LIMIT,
-                "gasPrice": 0
+                "gasPrice": 0,
             }
         )
-        nonce = web3.eth.getTransactionCount(TestAccount.address)
+        nonce = web3.eth.get_transaction_count(TestAccount.address)
         tx["nonce"] = nonce
         signed_tx = web3.eth.account.sign_transaction(
-            transaction_dict=tx,
-            private_key=TestAccount.private_key
+            transaction_dict=tx, private_key=TestAccount.private_key
         )
-        tx_hash = web3.eth.sendRawTransaction(signed_tx.rawTransaction.hex())
-        txn_receipt = web3.eth.waitForTransactionReceipt(
-            transaction_hash=tx_hash,
-            timeout=10
+        tx_hash = web3.eth.send_raw_transaction(signed_tx.rawTransaction.hex())
+        txn_receipt = web3.eth.wait_for_transaction_receipt(
+            transaction_hash=tx_hash, timeout=10
         )
 
         # Assertion
@@ -488,13 +492,9 @@ class TestE2E:
         not_deployed_func = {
             "inputs": [],
             "name": "notExistAttribute",
-            "outputs": [{
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }],
+            "outputs": [{"internalType": "address", "name": "", "type": "address"}],
             "stateMutability": "view",
-            "type": "function"
+            "type": "function",
         }
         # Inject invalid contract function to ABI
         contract_json["abi"].append(not_deployed_func)
@@ -502,7 +502,7 @@ class TestE2E:
         # Create contract object with invalid ABI
         contract_with_invalid_abi = web3.eth.contract(
             address=to_checksum_address(DEPLOYED_CONTRACT_ADDRESS),
-            abi=contract_json['abi'],
+            abi=contract_json["abi"],
         )
         _function = getattr(contract_with_invalid_abi.functions, "notExistAttribute")
         args = []

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,7 @@
 pytest==6.2.2
-eth-keyfile==0.5.1
-eth-utils==1.10.0
+eth-keyfile==0.6.1
+eth-utils==2.1.1
 py-solc-x==1.1.1
-web3==5.15.0
+web3==6.5.0
+isort==5.12.0
+black==23.3.0


### PR DESCRIPTION
- Upgrade web3py
- Fix unit test bug
- Introduce `isort` and `black`


Test execution result in local environment
```
$ make test
pytest tests/ 
========================================================================================================= test session starts =========================================================================================================
platform darwin -- Python 3.8.7, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /Users/yoshihito/dev/ibet-Network
plugins: web3-6.5.0
collected 16 items                                                                                                                                                                                                                    

tests/e2e_test.py ................                                                                                                                                                                                              [100%]

========================================================================================================= 16 passed in 37.09s =========================================================================================================
```