### PR TITLE
Update to golang version 1.22

### DIFF
--- a/ibet-for-fin-network/general/Dockerfile
+++ b/ibet-for-fin-network/general/Dockerfile
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.21-alpine as builder
+FROM golang:1.22-alpine as builder
 
 WORKDIR /work
 
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.3.0_beta2
+    git checkout v2.3.0_beta3
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/ibet-for-fin-network/validator/Dockerfile
+++ b/ibet-for-fin-network/validator/Dockerfile
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.21-alpine as builder
+FROM golang:1.22-alpine as builder
 
 WORKDIR /work
 
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.3.0_beta2
+    git checkout v2.3.0_beta3
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/ibet-network/general/Dockerfile
+++ b/ibet-network/general/Dockerfile
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.21-alpine as builder
+FROM golang:1.22-alpine as builder
 
 WORKDIR /work
 
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.3.0_beta2
+    git checkout v2.3.0_beta3
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/ibet-network/validator/Dockerfile
+++ b/ibet-network/validator/Dockerfile
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.21-alpine as builder
+FROM golang:1.22-alpine as builder
 
 WORKDIR /work
 
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.3.0_beta2
+    git checkout v2.3.0_beta3
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/local-network/docker-compose.yml
+++ b/local-network/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   validator-0:
     hostname: validator-0
-    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.3.0_beta2
+    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.3.0_beta3
     volumes:
       - /home/ubuntu/quorum_data/v0:/eth
     environment:
@@ -24,7 +24,7 @@ services:
     restart: always
   validator-1:
     hostname: validator-1
-    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.3.0_beta2
+    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.3.0_beta3
     volumes:
       - /home/ubuntu/quorum_data/v1:/eth
     environment:
@@ -46,7 +46,7 @@ services:
     restart: always
   validator-2:
     hostname: validator-2
-    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.3.0_beta2
+    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.3.0_beta3
     volumes:
       - /home/ubuntu/quorum_data/v2:/eth
     environment:
@@ -68,7 +68,7 @@ services:
     restart: always
   validator-3:
     hostname: validator-3
-    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.3.0_beta2
+    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.3.0_beta3
     volumes:
       - /home/ubuntu/quorum_data/v3:/eth
     environment:
@@ -90,7 +90,7 @@ services:
     restart: always
   general-0:
     hostname: general-0
-    image: ghcr.io/boostryjp/ibet-localnet/general:v2.3.0_beta2
+    image: ghcr.io/boostryjp/ibet-localnet/general:v2.3.0_beta3
     volumes:
       - /home/ubuntu/quorum_data/g0:/eth
     environment:

--- a/local-network/general/Dockerfile
+++ b/local-network/general/Dockerfile
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.21-alpine as builder
+FROM golang:1.22-alpine as builder
 
 WORKDIR /work
 
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.3.0_beta2
+    git checkout v2.3.0_beta3
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/local-network/validator/Dockerfile
+++ b/local-network/validator/Dockerfile
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.21-alpine as builder
+FROM golang:1.22-alpine as builder
 
 WORKDIR /work
 
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.3.0_beta2
+    git checkout v2.3.0_beta3
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/test-network/general/Dockerfile
+++ b/test-network/general/Dockerfile
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.21-alpine as builder
+FROM golang:1.22-alpine as builder
 
 WORKDIR /work
 
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.3.0_beta2
+    git checkout v2.3.0_beta3
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/test-network/validator/Dockerfile
+++ b/test-network/validator/Dockerfile
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.21-alpine as builder
+FROM golang:1.22-alpine as builder
 
 WORKDIR /work
 
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.3.0_beta2
+    git checkout v2.3.0_beta3
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \


### PR DESCRIPTION
In the PR below, the Go language version has been updated to v1.22. Therefore, update the Go version of the container image.
- https://github.com/BoostryJP/quorum/pull/76