### PR TITLE
Add EmptyBlockNumber for ibet-for-fin network

### DIFF
--- a/ibet-for-fin-network/validator/genesis.json
+++ b/ibet-for-fin-network/validator/genesis.json
@@ -18,7 +18,7 @@
         },
         "transitions": [
             {
-                "block": 999999999,
+                "block": 138252978,
                 "emptyBlockPeriodSeconds": 10
             }
         ],


### PR DESCRIPTION
We plan to enable emptyBlockPeriodSeconds for ibet-for-fin network at around 10:00 on Saturday, March 1st, so we will modify the transition block number of EmptyBlock in genesis.json.