### PR TITLE
Update Quorum version to v2.6.0_beta2

### DIFF
--- a/ibet-for-fin-network/general/Dockerfile
+++ b/ibet-for-fin-network/general/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.6.0_beta1
+    git checkout v2.6.0_beta2
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/ibet-for-fin-network/validator/Dockerfile
+++ b/ibet-for-fin-network/validator/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.6.0_beta1
+    git checkout v2.6.0_beta2
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/ibet-network/general/Dockerfile
+++ b/ibet-network/general/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.6.0_beta1
+    git checkout v2.6.0_beta2
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/ibet-network/validator/Dockerfile
+++ b/ibet-network/validator/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.6.0_beta1
+    git checkout v2.6.0_beta2
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/local-network/docker-compose.yml
+++ b/local-network/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   validator-0:
     hostname: validator-0
-    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.6.0_beta1
+    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.6.0_beta2
     volumes:
       - /home/ubuntu/quorum_data/v0:/eth
     environment:
@@ -28,7 +28,7 @@ services:
     restart: always
   validator-1:
     hostname: validator-1
-    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.6.0_beta1
+    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.6.0_beta2
     volumes:
       - /home/ubuntu/quorum_data/v1:/eth
     environment:
@@ -55,7 +55,7 @@ services:
     restart: always
   validator-2:
     hostname: validator-2
-    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.6.0_beta1
+    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.6.0_beta2
     volumes:
       - /home/ubuntu/quorum_data/v2:/eth
     environment:
@@ -82,7 +82,7 @@ services:
     restart: always
   validator-3:
     hostname: validator-3
-    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.6.0_beta1
+    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.6.0_beta2
     volumes:
       - /home/ubuntu/quorum_data/v3:/eth
     environment:
@@ -109,7 +109,7 @@ services:
     restart: always
   general-0:
     hostname: general-0
-    image: ghcr.io/boostryjp/ibet-localnet/general:v2.6.0_beta1
+    image: ghcr.io/boostryjp/ibet-localnet/general:v2.6.0_beta2
     volumes:
       - /home/ubuntu/quorum_data/g0:/eth
     environment:

--- a/local-network/general/Dockerfile
+++ b/local-network/general/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.6.0_beta1
+    git checkout v2.6.0_beta2
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/local-network/validator/Dockerfile
+++ b/local-network/validator/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.6.0_beta1
+    git checkout v2.6.0_beta2
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/test-network/general/Dockerfile
+++ b/test-network/general/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.6.0_beta1
+    git checkout v2.6.0_beta2
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/test-network/validator/Dockerfile
+++ b/test-network/validator/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.6.0_beta1
+    git checkout v2.6.0_beta2
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \


### PR DESCRIPTION
Bump Quorum version from v2.6.0_beta1 to v2.6.0_beta2 in all Dockerfiles and update Docker Compose images accordingly.

- https://github.com/BoostryJP/quorum/releases/tag/v2.6.0_beta2