### PR TITLE
Upgrade quorum image

### DIFF
--- a/ibet-for-fin-network/general/Dockerfile
+++ b/ibet-for-fin-network/general/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.6.0_beta2
+    git checkout v2.6.0
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/ibet-for-fin-network/validator/Dockerfile
+++ b/ibet-for-fin-network/validator/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.6.0_beta2
+    git checkout v2.6.0
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/ibet-network/general/Dockerfile
+++ b/ibet-network/general/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.6.0_beta2
+    git checkout v2.6.0
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/ibet-network/validator/Dockerfile
+++ b/ibet-network/validator/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.6.0_beta2
+    git checkout v2.6.0
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/local-network/docker-compose.yml
+++ b/local-network/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   validator-0:
     hostname: validator-0
-    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.6.0_beta2
+    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.6.0
     volumes:
       - /home/ubuntu/quorum_data/v0:/eth
     environment:
@@ -28,7 +28,7 @@ services:
     restart: always
   validator-1:
     hostname: validator-1
-    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.6.0_beta2
+    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.6.0
     volumes:
       - /home/ubuntu/quorum_data/v1:/eth
     environment:
@@ -55,7 +55,7 @@ services:
     restart: always
   validator-2:
     hostname: validator-2
-    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.6.0_beta2
+    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.6.0
     volumes:
       - /home/ubuntu/quorum_data/v2:/eth
     environment:
@@ -82,7 +82,7 @@ services:
     restart: always
   validator-3:
     hostname: validator-3
-    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.6.0_beta2
+    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.6.0
     volumes:
       - /home/ubuntu/quorum_data/v3:/eth
     environment:
@@ -109,7 +109,7 @@ services:
     restart: always
   general-0:
     hostname: general-0
-    image: ghcr.io/boostryjp/ibet-localnet/general:v2.6.0_beta2
+    image: ghcr.io/boostryjp/ibet-localnet/general:v2.6.0
     volumes:
       - /home/ubuntu/quorum_data/g0:/eth
     environment:

--- a/local-network/general/Dockerfile
+++ b/local-network/general/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.6.0_beta2
+    git checkout v2.6.0
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/local-network/validator/Dockerfile
+++ b/local-network/validator/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.6.0_beta2
+    git checkout v2.6.0
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/test-network/general/Dockerfile
+++ b/test-network/general/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.6.0_beta2
+    git checkout v2.6.0
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/test-network/validator/Dockerfile
+++ b/test-network/validator/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.6.0_beta2
+    git checkout v2.6.0
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \


### PR DESCRIPTION
This pull request updates the Quorum version used throughout the project from `v2.6.0_beta2` to the stable release `v2.6.0`. 

Version update to stable release:

* All Dockerfiles in `local-network`, `test-network`, `ibet-network`, and `ibet-for-fin-network` now clone and checkout Quorum at `v2.6.0` instead of `v2.6.0_beta2`, ensuring consistency and stability in the build process. [[1]](diffhunk://#diff-f84c04ae7cc0185f918f9328ccd29d0e955c49fe4b03374f83525f2c1c051798L10-R10) [[2]](diffhunk://#diff-d1a06db141b86a22b51e031d57e36b61f28ed2fc1a28ca0851f5bc1d6148bd9aL10-R10) [[3]](diffhunk://#diff-b3c35a5c83aa8bee2fb473b062d29438b02d2587f207f6527bd337522d539d50L10-R10)

Container image updates:

* The `local-network/docker-compose.yml` file has been updated so all `validator` and `general` service images now use the `v2.6.0` tag, replacing the previous `v2.6.0_beta2` tag. This ensures all containers run the stable Quorum version. [[1]](diffhunk://#diff-00057302f622d76b3e91dcc622703daf60ea07cef971260223329b0364b19e00L4-R4) [[2]](diffhunk://#diff-00057302f622d76b3e91dcc622703daf60ea07cef971260223329b0364b19e00L31-R31) [[3]](diffhunk://#diff-00057302f622d76b3e91dcc622703daf60ea07cef971260223329b0364b19e00L58-R58) [[4]](diffhunk://#diff-00057302f622d76b3e91dcc622703daf60ea07cef971260223329b0364b19e00L85-R85) [[5]](diffhunk://#diff-00057302f622d76b3e91dcc622703daf60ea07cef971260223329b0364b19e00L112-R112)