### PR TITLE
Add Dependabot config for GitHub Actions and pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/tests"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(pip)"
+      include: "scope"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
This pull request introduces a new `.github/dependabot.yml` configuration file to automate dependency updates for GitHub Actions and Python packages in the project.

Dependency automation setup:

* Added `.github/dependabot.yml` to enable Dependabot for GitHub Actions and Python (`pip`) dependencies, including update schedules and grouping of all dependencies.