### PR TITLE
Add P-256 precompile tests

### DIFF
--- a/tests/contracts/E2ETest.sol
+++ b/tests/contracts/E2ETest.sol
@@ -192,6 +192,56 @@ contract E2ETest {
         return itemsValue;
     }
 
+    /// @notice Call P-256 verification precompile and parse return values.
+    /// @dev Expected precompile address is 0x0100.
+    /// @return callSuccess low-level staticcall result
+    /// @return verified true when return value is 32-byte 0x...01
+    /// @return rawResult raw bytes returned by the precompile
+    function verifyP256Result(
+        bytes32 _hash,
+        bytes32 _r,
+        bytes32 _s,
+        bytes32 _qx,
+        bytes32 _qy
+    )
+        public
+        view
+        returns (
+            bool callSuccess,
+            bool verified,
+            bytes memory rawResult
+        )
+    {
+        (callSuccess, rawResult) = address(0x0100).staticcall(
+            abi.encodePacked(_hash, _r, _s, _qx, _qy)
+        );
+
+        verified = false;
+        if (rawResult.length == 32) {
+            uint256 value;
+            assembly {
+                value := mload(add(rawResult, 32))
+            }
+            verified = (value == 1);
+        }
+    }
+
+    /// @notice Call P-256 verification precompile with arbitrary input bytes.
+    /// @return callSuccess low-level staticcall result
+    /// @return rawResult raw bytes returned by the precompile
+    function verifyP256Raw(
+        bytes calldata _input
+    )
+        external
+        view
+        returns (
+            bool callSuccess,
+            bytes memory rawResult
+        )
+    {
+        (callSuccess, rawResult) = address(0x0100).staticcall(_input);
+    }
+
     /// @notice Get optional item
     /// @param _optional_item optional item
     function setOptionalItem(

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -18,6 +18,9 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import pytest
+from Crypto.Hash import SHA256
+from Crypto.PublicKey import ECC
+from Crypto.Signature import DSS
 from eth_utils import keccak, to_checksum_address
 from web3 import Web3
 from web3.datastructures import AttributeDict
@@ -35,6 +38,29 @@ from tests.util import ContractUtils, TestAccount
 
 web3 = Web3(Web3.HTTPProvider(WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
+
+
+def _to_bytes32(value: int) -> bytes:
+    return value.to_bytes(32, byteorder="big")
+
+
+def _get_p256_vector() -> tuple[bytes, bytes, bytes, bytes, bytes]:
+    # Deterministic test vector to keep E2E reproducible.
+    private_key = int(
+        "1f1e1d1c1b1a191817161514131211101f1e1d1c1b1a19181716151413121110", 16
+    )
+    key = ECC.construct(curve="P-256", d=private_key)
+    message = b"ibet-network-p256-e2e"
+    hash_bytes = SHA256.new(message).digest()
+    signature = DSS.new(key, "deterministic-rfc6979", encoding="binary").sign(
+        SHA256.new(message)
+    )
+
+    r_bytes = signature[:32]
+    s_bytes = signature[32:64]
+    qx_bytes = _to_bytes32(int(key.pointQ.x))
+    qy_bytes = _to_bytes32(int(key.pointQ.y))
+    return hash_bytes, r_bytes, s_bytes, qx_bytes, qy_bytes
 
 
 # NOTE:
@@ -321,6 +347,20 @@ class TestE2E:
         # Assertion
         assert bytecode.to_0x_hex() == "0x"
 
+    # <Normal_8_1>
+    # Verify secp256r1 signature by precompile (0x0100)
+    # - eth_call
+    def test_normal_8_1(self, contract):
+        hash_bytes, r_bytes, s_bytes, qx_bytes, qy_bytes = _get_p256_vector()
+        call_success, verified, raw_result = contract.functions.verifyP256Result(
+            hash_bytes, r_bytes, s_bytes, qx_bytes, qy_bytes
+        ).call()
+
+        # Assertion
+        assert call_success is True
+        assert verified is True
+        assert raw_result == (b"\x00" * 31) + b"\x01"
+
     ###########################################################################
     # Error Case
     ###########################################################################
@@ -536,3 +576,34 @@ class TestE2E:
             Web3RPCError, match="{'code': -32000, 'message': 'already known'}"
         ):
             _ = web3.eth.send_raw_transaction(signed_tx.raw_transaction.to_0x_hex())
+
+    # <Error_7_1>
+    # Invalid signature for secp256r1 precompile
+    # - eth_call
+    def test_error_7_1(self, contract):
+        hash_bytes, r_bytes, s_bytes, qx_bytes, qy_bytes = _get_p256_vector()
+        invalid_s = bytes([s_bytes[0] ^ 0x01]) + s_bytes[1:]
+        call_success, verified, raw_result = contract.functions.verifyP256Result(
+            hash_bytes, r_bytes, invalid_s, qx_bytes, qy_bytes
+        ).call()
+
+        # Assertion
+        assert call_success is True
+        assert verified is False
+        assert raw_result == b""
+
+    # <Error_7_2>
+    # Invalid input length for secp256r1 precompile
+    # - eth_call
+    def test_error_7_2(self, contract):
+        hash_bytes, r_bytes, s_bytes, qx_bytes, qy_bytes = _get_p256_vector()
+        valid_input = hash_bytes + r_bytes + s_bytes + qx_bytes + qy_bytes
+        invalid_length_input = valid_input[:-1]
+        call_success, raw_result = contract.functions.verifyP256Raw(
+            invalid_length_input
+        ).call()
+
+        # Assertion
+        assert len(invalid_length_input) == 159
+        assert call_success is True
+        assert raw_result == b""

--- a/tests/poetry.lock
+++ b/tests/poetry.lock
@@ -2306,4 +2306,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "3.13.11"
-content-hash = "1efb7bf2dfdccb3fd8b52cb2491d08f1934d1ce6dc1b1394f9b0b2b9bf4e947d"
+content-hash = "1219108183a9e5e06d95df2e52f2b8c7aeabe10c9da0f954ac767ec3cffeae64"

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -14,6 +14,7 @@ eth-utils = "~5.3.1"
 py-solc-x = "2.0.5"
 web3 = "~7.14.1"
 coincurve = "~21.0.0"
+pycryptodome = "^3.23.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Related to: https://github.com/BoostryJP/quorum/pull/136

- Add Solidity helpers verifyP256Result and verifyP256Raw to E2ETest.sol to call the P-256 verification precompile (0x0100) and parse its return.
- Add Python test utilities to generate a deterministic P-256 vector and three tests (normal success, invalid signature, and invalid input length) to exercise the precompile via eth_call.