### PR TITLE
Update Quorum tag to v2.7.0 in Dockerfiles

### DIFF
--- a/ibet-for-fin-network/general/Dockerfile
+++ b/ibet-for-fin-network/general/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.7.0_beta3
+    git checkout v2.7.0
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/ibet-for-fin-network/validator/Dockerfile
+++ b/ibet-for-fin-network/validator/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.7.0_beta3
+    git checkout v2.7.0
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/local-network/general/Dockerfile
+++ b/local-network/general/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.7.0_beta3
+    git checkout v2.7.0
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/local-network/validator/Dockerfile
+++ b/local-network/validator/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.7.0_beta3
+    git checkout v2.7.0
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/test-network/general/Dockerfile
+++ b/test-network/general/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.7.0_beta3
+    git checkout v2.7.0
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/test-network/validator/Dockerfile
+++ b/test-network/validator/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/quorum.git && \
     cd quorum/ && \
-    git checkout v2.7.0_beta3
+    git checkout v2.7.0
 RUN cd quorum/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \


### PR DESCRIPTION
Bump the checked-out Quorum revision from v2.7.0_beta3 to the v2.7.0.
