### PR TITLE
Add AWS SM nodekey support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # ibet-Network
 
 <p>
-  <img alt="Version" src="https://img.shields.io/badge/version-2.7-blue.svg?cacheSeconds=2592000" />
+  <img alt="Version" src="https://img.shields.io/badge/version-2.8-blue.svg?cacheSeconds=2592000" />
 </p>
 
 English | [日本語](./README_JA.md)

--- a/README_JA.md
+++ b/README_JA.md
@@ -5,7 +5,7 @@
 # ibet-Network
 
 <p>
-  <img alt="Version" src="https://img.shields.io/badge/version-2.7-blue.svg?cacheSeconds=2592000" />
+  <img alt="Version" src="https://img.shields.io/badge/version-2.8-blue.svg?cacheSeconds=2592000" />
 </p>
 
 [English](./README.md) | 日本語

--- a/ibet-for-fin-network/README.md
+++ b/ibet-for-fin-network/README.md
@@ -37,8 +37,8 @@ Node key settings are also configurable through environment variables.
 * `nodekeysource` Node key source (`file` or `aws-sm`)  
 * `nodekeydecryption` Node key decryption (`none` or `aws-kms`)  
 * `nodekey_aws_secret_name` AWS Secrets Manager secret name or ARN  
-* `nodekey_aws_secret_version_id` Optional AWS secret version ID  
-* `nodekey_aws_secret_version_stage` Optional AWS secret version stage, such as `AWSCURRENT`  
+* `nodekey_aws_secret_version_id` AWS secret version ID, required when `nodekeysource=aws-sm` and `nodekey_aws_secret_version_stage` is not set (exactly one of `nodekey_aws_secret_version_id` or `nodekey_aws_secret_version_stage` must be set)  
+* `nodekey_aws_secret_version_stage` AWS secret version stage, such as `AWSCURRENT`, required when `nodekeysource=aws-sm` and `nodekey_aws_secret_version_id` is not set (exactly one of `nodekey_aws_secret_version_id` or `nodekey_aws_secret_version_stage` must be set)  
 * `nodekey_aws_kms_key_id` AWS KMS key ID or alias, required when `nodekeydecryption=aws-kms`  
 * `nodekey_aws_kms_encryption_algorithm` Optional KMS encryption algorithm override, such as `RSAES_OAEP_SHA_256`  
 

--- a/ibet-for-fin-network/README.md
+++ b/ibet-for-fin-network/README.md
@@ -30,6 +30,20 @@ Common to all three types of nodes, you need to set the following environment va
 * `rpcvhosts` Comma separated list of virtual hostnames from which to accept requests (default: "localhost")  
 * `maxpeers` Maximum number of network peers (network disabled if set to 0) (default: 50)  
 
+Node key settings are also configurable through environment variables.
+
+* `nodekey` Path to the legacy node key file inside the container  
+* `nodekeyhex` Legacy node key as hex string  
+* `nodekeysource` Node key source (`file` or `aws-sm`)  
+* `nodekeydecryption` Node key decryption (`none` or `aws-kms`)  
+* `nodekey_aws_secret_name` AWS Secrets Manager secret name or ARN  
+* `nodekey_aws_secret_version_id` Optional AWS secret version ID  
+* `nodekey_aws_secret_version_stage` Optional AWS secret version stage, such as `AWSCURRENT`  
+* `nodekey_aws_kms_key_id` AWS KMS key ID or alias, required when `nodekeydecryption=aws-kms`  
+* `nodekey_aws_kms_encryption_algorithm` Optional KMS encryption algorithm override, such as `RSAES_OAEP_SHA_256`  
+
+When `nodekey` or `nodekeyhex` is specified, the legacy configuration takes precedence and no additional AWS configuration is required.
+
 ## 2. Start/Stop Validator node
 
 ### Set up
@@ -61,6 +75,18 @@ Finally, start the node as follows.
 ```
 $ docker run -d --name validator -e PRIVATE_CONFIG=ignore -e nodekeyhex={nodekey} -v {mount_directory}:/eth \
     ghcr.io/boostryjp/ibet-fin-network/validator:{version} run.sh 
+```
+
+To load the validator node key from AWS Secrets Manager instead, start it as follows.
+```
+$ docker run -d --name validator -e PRIVATE_CONFIG=ignore \
+    -e nodekeysource=aws-sm \
+    -e nodekeydecryption=aws-kms \
+    -e nodekey_aws_secret_name={secret_name_or_arn} \
+    -e nodekey_aws_secret_version_stage=AWSCURRENT \
+    -e nodekey_aws_kms_key_id={kms_key_id_or_alias} \
+    -v {mount_directory}:/eth \
+    ghcr.io/boostryjp/ibet-fin-network/validator:{version} run.sh
 ```
 
 ### Stop validator node 
@@ -107,6 +133,8 @@ Finally, start the node as follows.
 $ docker run -d --name general -e PRIVATE_CONFIG=ignore -v {mount_direcotry}:/eth \
     ghcr.io/boostryjp/ibet-fin-network/general:{version} run.sh 
 ```
+
+The same AWS node key settings can be used for Bridge and General nodes as well.
 
 ### Stop node 
 When stopping a node, simply stop the container.

--- a/ibet-for-fin-network/README.md
+++ b/ibet-for-fin-network/README.md
@@ -43,6 +43,7 @@ Node key settings are also configurable through environment variables.
 * `nodekey_aws_kms_encryption_algorithm` Optional KMS encryption algorithm override, such as `RSAES_OAEP_SHA_256`  
 
 When `nodekey` or `nodekeyhex` is specified, the legacy configuration takes precedence and no additional AWS configuration is required.
+Validator nodes must set one of `nodekey`, `nodekeyhex`, or `nodekeysource` explicitly.
 
 ## 2. Start/Stop Validator node
 

--- a/ibet-for-fin-network/general/run.sh
+++ b/ibet-for-fin-network/general/run.sh
@@ -1,6 +1,69 @@
 #!/bin/ash
 mkdir -p /eth/geth
 
+escape_toml_string() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+setup_nodekey_options() {
+  NODEKEY_SOURCE="${nodekeysource:-file}"
+  NODEKEY_DECRYPTION="${nodekeydecryption:-none}"
+
+  if [ -n "${nodekey}" ]; then
+    NODEKEY_OPT="--nodekey ${nodekey}"
+    return 0
+  fi
+  if [ -n "${nodekeyhex}" ]; then
+    NODEKEY_OPT="--nodekeyhex ${nodekeyhex}"
+    return 0
+  fi
+
+  if [ "${NODEKEY_SOURCE}" = "aws-sm" ]; then
+    if [ -z "${nodekey_aws_secret_name}" ]; then
+      echo "$0: nodekey_aws_secret_name is required when nodekeysource=aws-sm." >&2
+      return 1
+    fi
+    if [ -n "${nodekey_aws_secret_version_id}" ] && [ -n "${nodekey_aws_secret_version_stage}" ]; then
+      echo "$0: nodekey_aws_secret_version_id and nodekey_aws_secret_version_stage are mutually exclusive." >&2
+      return 1
+    fi
+    if [ -z "${nodekey_aws_secret_version_id}" ] && [ -z "${nodekey_aws_secret_version_stage}" ]; then
+      echo "$0: either nodekey_aws_secret_version_id or nodekey_aws_secret_version_stage is required when nodekeysource=aws-sm." >&2
+      return 1
+    fi
+    if [ "${NODEKEY_DECRYPTION}" = "aws-kms" ] && [ -z "${nodekey_aws_kms_key_id}" ]; then
+      echo "$0: nodekey_aws_kms_key_id is required when nodekeydecryption=aws-kms." >&2
+      return 1
+    fi
+
+    CONFIG_FILE="/eth/config.toml"
+    {
+      printf '[Node.P2P.NodeKey.ConfigAws]\n'
+      printf 'SecretName = "%s"\n' "$(escape_toml_string "${nodekey_aws_secret_name}")"
+      if [ -n "${nodekey_aws_secret_version_id}" ]; then
+        printf 'SecretVersionId = "%s"\n' "$(escape_toml_string "${nodekey_aws_secret_version_id}")"
+      fi
+      if [ -n "${nodekey_aws_secret_version_stage}" ]; then
+        printf 'SecretVersionStage = "%s"\n' "$(escape_toml_string "${nodekey_aws_secret_version_stage}")"
+      fi
+      if [ -n "${nodekey_aws_kms_key_id}" ]; then
+        printf 'KmsKeyId = "%s"\n' "$(escape_toml_string "${nodekey_aws_kms_key_id}")"
+      fi
+      if [ -n "${nodekey_aws_kms_encryption_algorithm}" ]; then
+        printf 'KmsEncryptionAlgorithm = "%s"\n' "$(escape_toml_string "${nodekey_aws_kms_encryption_algorithm}")"
+      fi
+    } > "${CONFIG_FILE}"
+    CONFIG_OPT="--config ${CONFIG_FILE}"
+  fi
+
+  if [ -n "${nodekeysource}" ] || [ -n "${nodekeydecryption}" ] || [ "${NODEKEY_SOURCE}" = "aws-sm" ]; then
+    NODEKEY_SOURCE_OPT="--nodekeysource ${NODEKEY_SOURCE}"
+    NODEKEY_DECRYPTION_OPT="--nodekeydecryption ${NODEKEY_DECRYPTION}"
+  fi
+}
+
+setup_nodekey_options || exit 1
+
 test ! -z "${rpccorsdomain}" && CORS_OPT="--http.corsdomain ${rpccorsdomain}"
 test ! -z "${rpcvhosts}" && VHOST_OPT="--http.vhosts ${rpcvhosts}"
 test ! -z "${maxpeers}" && PEERS_OPT="--maxpeers ${maxpeers}"
@@ -28,6 +91,10 @@ ${VHOST_OPT} \
 ${PEERS_OPT} \
 ${SYNCMODE_OPT} \
 ${CACHE_OPT} \
+${CONFIG_OPT} \
+${NODEKEY_OPT} \
+${NODEKEY_SOURCE_OPT} \
+${NODEKEY_DECRYPTION_OPT} \
 ${CACHE_GC_OPT}"
 
 if [ -z "${BLOCK_SYNC_MONITORING_DISABLED}" ] || [ "${BLOCK_SYNC_MONITORING_DISABLED}" -ne 1 ]; then

--- a/ibet-for-fin-network/validator/run.sh
+++ b/ibet-for-fin-network/validator/run.sh
@@ -6,6 +6,11 @@ escape_toml_string() {
 }
 
 setup_nodekey_options() {
+  if [ -z "${nodekey}" ] && [ -z "${nodekeyhex}" ] && [ -z "${nodekeysource}" ]; then
+    echo "$0: validator nodes require nodekey, nodekeyhex, or nodekeysource to be set." >&2
+    return 1
+  fi
+
   NODEKEY_SOURCE="${nodekeysource:-file}"
   NODEKEY_DECRYPTION="${nodekeydecryption:-none}"
 

--- a/ibet-for-fin-network/validator/run.sh
+++ b/ibet-for-fin-network/validator/run.sh
@@ -1,6 +1,69 @@
 #!/bin/ash
 mkdir -p /eth/geth
 
+escape_toml_string() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+setup_nodekey_options() {
+  NODEKEY_SOURCE="${nodekeysource:-file}"
+  NODEKEY_DECRYPTION="${nodekeydecryption:-none}"
+
+  if [ -n "${nodekey}" ]; then
+    NODEKEY_OPT="--nodekey ${nodekey}"
+    return 0
+  fi
+  if [ -n "${nodekeyhex}" ]; then
+    NODEKEY_OPT="--nodekeyhex ${nodekeyhex}"
+    return 0
+  fi
+
+  if [ "${NODEKEY_SOURCE}" = "aws-sm" ]; then
+    if [ -z "${nodekey_aws_secret_name}" ]; then
+      echo "$0: nodekey_aws_secret_name is required when nodekeysource=aws-sm." >&2
+      return 1
+    fi
+    if [ -n "${nodekey_aws_secret_version_id}" ] && [ -n "${nodekey_aws_secret_version_stage}" ]; then
+      echo "$0: nodekey_aws_secret_version_id and nodekey_aws_secret_version_stage are mutually exclusive." >&2
+      return 1
+    fi
+    if [ -z "${nodekey_aws_secret_version_id}" ] && [ -z "${nodekey_aws_secret_version_stage}" ]; then
+      echo "$0: either nodekey_aws_secret_version_id or nodekey_aws_secret_version_stage is required when nodekeysource=aws-sm." >&2
+      return 1
+    fi
+    if [ "${NODEKEY_DECRYPTION}" = "aws-kms" ] && [ -z "${nodekey_aws_kms_key_id}" ]; then
+      echo "$0: nodekey_aws_kms_key_id is required when nodekeydecryption=aws-kms." >&2
+      return 1
+    fi
+
+    CONFIG_FILE="/eth/config.toml"
+    {
+      printf '[Node.P2P.NodeKey.ConfigAws]\n'
+      printf 'SecretName = "%s"\n' "$(escape_toml_string "${nodekey_aws_secret_name}")"
+      if [ -n "${nodekey_aws_secret_version_id}" ]; then
+        printf 'SecretVersionId = "%s"\n' "$(escape_toml_string "${nodekey_aws_secret_version_id}")"
+      fi
+      if [ -n "${nodekey_aws_secret_version_stage}" ]; then
+        printf 'SecretVersionStage = "%s"\n' "$(escape_toml_string "${nodekey_aws_secret_version_stage}")"
+      fi
+      if [ -n "${nodekey_aws_kms_key_id}" ]; then
+        printf 'KmsKeyId = "%s"\n' "$(escape_toml_string "${nodekey_aws_kms_key_id}")"
+      fi
+      if [ -n "${nodekey_aws_kms_encryption_algorithm}" ]; then
+        printf 'KmsEncryptionAlgorithm = "%s"\n' "$(escape_toml_string "${nodekey_aws_kms_encryption_algorithm}")"
+      fi
+    } > "${CONFIG_FILE}"
+    CONFIG_OPT="--config ${CONFIG_FILE}"
+  fi
+
+  if [ -n "${nodekeysource}" ] || [ -n "${nodekeydecryption}" ] || [ "${NODEKEY_SOURCE}" = "aws-sm" ]; then
+    NODEKEY_SOURCE_OPT="--nodekeysource ${NODEKEY_SOURCE}"
+    NODEKEY_DECRYPTION_OPT="--nodekeydecryption ${NODEKEY_DECRYPTION}"
+  fi
+}
+
+setup_nodekey_options || exit 1
+
 test ! -z "${rpccorsdomain}" && CORS_OPT="--http.corsdomain ${rpccorsdomain}"
 test ! -z "${rpcvhosts}" && VHOST_OPT="--http.vhosts ${rpcvhosts}"
 test ! -z "${maxpeers}" && PEERS_OPT="--maxpeers ${maxpeers}"
@@ -20,7 +83,6 @@ ${IDENTITY_OPT} \
 ${VHOST_OPT} \
 --networkid 1010032 \
 --nat any \
---nodekeyhex $nodekeyhex \
 --mine \
 --syncmode full \
 --verbosity ${verbosity:-2} \
@@ -28,6 +90,10 @@ ${VHOST_OPT} \
 --miner.gastarget 800000000 \
 ${PEERS_OPT} \
 ${CACHE_OPT} \
+${CONFIG_OPT} \
+${NODEKEY_OPT} \
+${NODEKEY_SOURCE_OPT} \
+${NODEKEY_DECRYPTION_OPT} \
 ${CACHE_GC_OPT}"
 
 ash -c "nohup ${GETH_CMD//\*/\\\*} > /dev/stdout 2>&1 &"

--- a/local-network/general/run.sh
+++ b/local-network/general/run.sh
@@ -1,6 +1,69 @@
 #!/bin/ash
 mkdir -p /eth/geth
 
+escape_toml_string() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+setup_nodekey_options() {
+  NODEKEY_SOURCE="${nodekeysource:-file}"
+  NODEKEY_DECRYPTION="${nodekeydecryption:-none}"
+
+  if [ -n "${nodekey}" ]; then
+    NODEKEY_OPT="--nodekey ${nodekey}"
+    return 0
+  fi
+  if [ -n "${nodekeyhex}" ]; then
+    NODEKEY_OPT="--nodekeyhex ${nodekeyhex}"
+    return 0
+  fi
+
+  if [ "${NODEKEY_SOURCE}" = "aws-sm" ]; then
+    if [ -z "${nodekey_aws_secret_name}" ]; then
+      echo "$0: nodekey_aws_secret_name is required when nodekeysource=aws-sm." >&2
+      return 1
+    fi
+    if [ -n "${nodekey_aws_secret_version_id}" ] && [ -n "${nodekey_aws_secret_version_stage}" ]; then
+      echo "$0: nodekey_aws_secret_version_id and nodekey_aws_secret_version_stage are mutually exclusive." >&2
+      return 1
+    fi
+    if [ -z "${nodekey_aws_secret_version_id}" ] && [ -z "${nodekey_aws_secret_version_stage}" ]; then
+      echo "$0: either nodekey_aws_secret_version_id or nodekey_aws_secret_version_stage is required when nodekeysource=aws-sm." >&2
+      return 1
+    fi
+    if [ "${NODEKEY_DECRYPTION}" = "aws-kms" ] && [ -z "${nodekey_aws_kms_key_id}" ]; then
+      echo "$0: nodekey_aws_kms_key_id is required when nodekeydecryption=aws-kms." >&2
+      return 1
+    fi
+
+    CONFIG_FILE="/eth/config.toml"
+    {
+      printf '[Node.P2P.NodeKey.ConfigAws]\n'
+      printf 'SecretName = "%s"\n' "$(escape_toml_string "${nodekey_aws_secret_name}")"
+      if [ -n "${nodekey_aws_secret_version_id}" ]; then
+        printf 'SecretVersionId = "%s"\n' "$(escape_toml_string "${nodekey_aws_secret_version_id}")"
+      fi
+      if [ -n "${nodekey_aws_secret_version_stage}" ]; then
+        printf 'SecretVersionStage = "%s"\n' "$(escape_toml_string "${nodekey_aws_secret_version_stage}")"
+      fi
+      if [ -n "${nodekey_aws_kms_key_id}" ]; then
+        printf 'KmsKeyId = "%s"\n' "$(escape_toml_string "${nodekey_aws_kms_key_id}")"
+      fi
+      if [ -n "${nodekey_aws_kms_encryption_algorithm}" ]; then
+        printf 'KmsEncryptionAlgorithm = "%s"\n' "$(escape_toml_string "${nodekey_aws_kms_encryption_algorithm}")"
+      fi
+    } > "${CONFIG_FILE}"
+    CONFIG_OPT="--config ${CONFIG_FILE}"
+  fi
+
+  if [ -n "${nodekeysource}" ] || [ -n "${nodekeydecryption}" ] || [ "${NODEKEY_SOURCE}" = "aws-sm" ]; then
+    NODEKEY_SOURCE_OPT="--nodekeysource ${NODEKEY_SOURCE}"
+    NODEKEY_DECRYPTION_OPT="--nodekeydecryption ${NODEKEY_DECRYPTION}"
+  fi
+}
+
+setup_nodekey_options || exit 1
+
 echo '{"config":{"chainId":2017,"homesteadBlock":1,"eip150Block":2,"eip150Hash":"0x0000000000000000000000000000000000000000000000000000000000000000","eip155Block":3,"eip158Block":3,"byzantiumBlock":3,"constantinopleBlock":'${berlinBlock}',"petersburgBlock":'${berlinBlock}',"istanbulBlock":'${berlinBlock}',"berlinBlock":'${berlinBlock}',"istanbul":{"epoch":30000,"policy":0,"testQBFTBlock":'${testQBFTBlock}'}},"nonce":"0x0","timestamp":"0x5ad86387","extraData":"0x0000000000000000000000000000000000000000000000000000000000000000f89af8549447a847fbdf801154253593851ac9a2e7753235349403ee8c85944b16dfa517cb0ddefe123c7341a5349435d56a7515e824be4122f033d60063d035573a0c94c25d04978fd86ee604feb88f3c635d555eb6d42db8410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c0","gasLimit":"0x2faf0800","difficulty":"0x1","mixHash":"0x63746963616c2062797a616e74696e65206661756c7420746f6c6572616e6365","coinbase":"0x0000000000000000000000000000000000000000","alloc":{"03ee8c85944b16dfa517cb0ddefe123c7341a534":{"balance":"0x446c3b15f9926687d2c40534fdb564000000000000"},"35d56a7515e824be4122f033d60063d035573a0c":{"balance":"0x446c3b15f9926687d2c40534fdb564000000000000"},"47a847fbdf801154253593851ac9a2e775323534":{"balance":"0x446c3b15f9926687d2c40534fdb564000000000000"},"c25d04978fd86ee604feb88f3c635d555eb6d42d":{"balance":"0x446c3b15f9926687d2c40534fdb564000000000000"}},"number":"0x0","gasUsed":"0x0","parentHash":"0x0000000000000000000000000000000000000000000000000000000000000000"}' > /eth/genesis.json
 echo '["enode://6204d2b6d844adf9dd23f47027b29b1e39b08c70b8ec05f82a8037f1676c058fe80035b42f32c649cc47347889abfe7732139b9f3f243ea91f990d2d72bb87bd@172.16.239.10:30303?discport=0","enode://a573feff0859205b566385aaf85f4c858dfe4ebb07ec862a2d03e117b3e39d8220aaf1d58750440ad844ddcb623f6becc9ba07fc27db4d30cdf689f15a9b1462@172.16.239.11:30303?discport=0","enode://76b750a2a0c92d2411e4793c714a85cf01e527c7a77f70548e7f363feaf8320039cd0f2eb48235c022d39df44ec06c96060f5c25caeec8a1960a356ebd5473a1@172.16.239.12:30303?discport=0","enode://f53fff2c7ed693b627d4389b92b6d94a11b91f167193a5d31320a2b35fb752f79b3aed7dcc61961bc00b397fdf8729eb797a0b28d6c538d51232164432b67f80@172.16.239.13:30303?discport=0"]' > /eth/geth/static-nodes.json
 geth --datadir "/eth" init "/eth/genesis.json"
@@ -29,6 +92,10 @@ ${METRICS_OPT} \
 --miner.gastarget 800000000 \
 ${SYNCMODE_OPT} \
 ${CACHE_OPT} \
+${CONFIG_OPT} \
+${NODEKEY_OPT} \
+${NODEKEY_SOURCE_OPT} \
+${NODEKEY_DECRYPTION_OPT} \
 ${CACHE_GC_OPT}"
 
 if [ -z "${BLOCK_SYNC_MONITORING_DISABLED}" ] || [ "${BLOCK_SYNC_MONITORING_DISABLED}" -ne 1 ]; then

--- a/local-network/validator/run.sh
+++ b/local-network/validator/run.sh
@@ -6,6 +6,11 @@ escape_toml_string() {
 }
 
 setup_nodekey_options() {
+  if [ -z "${nodekey}" ] && [ -z "${nodekeyhex}" ] && [ -z "${nodekeysource}" ]; then
+    echo "$0: validator nodes require nodekey, nodekeyhex, or nodekeysource to be set." >&2
+    return 1
+  fi
+
   NODEKEY_SOURCE="${nodekeysource:-file}"
   NODEKEY_DECRYPTION="${nodekeydecryption:-none}"
 

--- a/local-network/validator/run.sh
+++ b/local-network/validator/run.sh
@@ -1,6 +1,69 @@
 #!/bin/ash
 mkdir -p /eth/geth
 
+escape_toml_string() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+setup_nodekey_options() {
+  NODEKEY_SOURCE="${nodekeysource:-file}"
+  NODEKEY_DECRYPTION="${nodekeydecryption:-none}"
+
+  if [ -n "${nodekey}" ]; then
+    NODEKEY_OPT="--nodekey ${nodekey}"
+    return 0
+  fi
+  if [ -n "${nodekeyhex}" ]; then
+    NODEKEY_OPT="--nodekeyhex ${nodekeyhex}"
+    return 0
+  fi
+
+  if [ "${NODEKEY_SOURCE}" = "aws-sm" ]; then
+    if [ -z "${nodekey_aws_secret_name}" ]; then
+      echo "$0: nodekey_aws_secret_name is required when nodekeysource=aws-sm." >&2
+      return 1
+    fi
+    if [ -n "${nodekey_aws_secret_version_id}" ] && [ -n "${nodekey_aws_secret_version_stage}" ]; then
+      echo "$0: nodekey_aws_secret_version_id and nodekey_aws_secret_version_stage are mutually exclusive." >&2
+      return 1
+    fi
+    if [ -z "${nodekey_aws_secret_version_id}" ] && [ -z "${nodekey_aws_secret_version_stage}" ]; then
+      echo "$0: either nodekey_aws_secret_version_id or nodekey_aws_secret_version_stage is required when nodekeysource=aws-sm." >&2
+      return 1
+    fi
+    if [ "${NODEKEY_DECRYPTION}" = "aws-kms" ] && [ -z "${nodekey_aws_kms_key_id}" ]; then
+      echo "$0: nodekey_aws_kms_key_id is required when nodekeydecryption=aws-kms." >&2
+      return 1
+    fi
+
+    CONFIG_FILE="/eth/config.toml"
+    {
+      printf '[Node.P2P.NodeKey.ConfigAws]\n'
+      printf 'SecretName = "%s"\n' "$(escape_toml_string "${nodekey_aws_secret_name}")"
+      if [ -n "${nodekey_aws_secret_version_id}" ]; then
+        printf 'SecretVersionId = "%s"\n' "$(escape_toml_string "${nodekey_aws_secret_version_id}")"
+      fi
+      if [ -n "${nodekey_aws_secret_version_stage}" ]; then
+        printf 'SecretVersionStage = "%s"\n' "$(escape_toml_string "${nodekey_aws_secret_version_stage}")"
+      fi
+      if [ -n "${nodekey_aws_kms_key_id}" ]; then
+        printf 'KmsKeyId = "%s"\n' "$(escape_toml_string "${nodekey_aws_kms_key_id}")"
+      fi
+      if [ -n "${nodekey_aws_kms_encryption_algorithm}" ]; then
+        printf 'KmsEncryptionAlgorithm = "%s"\n' "$(escape_toml_string "${nodekey_aws_kms_encryption_algorithm}")"
+      fi
+    } > "${CONFIG_FILE}"
+    CONFIG_OPT="--config ${CONFIG_FILE}"
+  fi
+
+  if [ -n "${nodekeysource}" ] || [ -n "${nodekeydecryption}" ] || [ "${NODEKEY_SOURCE}" = "aws-sm" ]; then
+    NODEKEY_SOURCE_OPT="--nodekeysource ${NODEKEY_SOURCE}"
+    NODEKEY_DECRYPTION_OPT="--nodekeydecryption ${NODEKEY_DECRYPTION}"
+  fi
+}
+
+setup_nodekey_options || exit 1
+
 echo '{"config":{"chainId":2017,"homesteadBlock":1,"eip150Block":2,"eip150Hash":"0x0000000000000000000000000000000000000000000000000000000000000000","eip155Block":3,"eip158Block":3,"byzantiumBlock":3,"constantinopleBlock":'${berlinBlock}',"petersburgBlock":'${berlinBlock}',"istanbulBlock":'${berlinBlock}',"berlinBlock":'${berlinBlock}',"istanbul":{"epoch":30000,"policy":0,"testQBFTBlock":'${testQBFTBlock}'},"transitions":[{"block":'${emptyBlockPeriodIntroduceBlock}',"emptyBlockPeriodSeconds":10}]},"nonce":"0x0","timestamp":"0x5ad86387","extraData":"0x0000000000000000000000000000000000000000000000000000000000000000f89af8549447a847fbdf801154253593851ac9a2e7753235349403ee8c85944b16dfa517cb0ddefe123c7341a5349435d56a7515e824be4122f033d60063d035573a0c94c25d04978fd86ee604feb88f3c635d555eb6d42db8410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c0","gasLimit":"0x2faf0800","difficulty":"0x1","mixHash":"0x63746963616c2062797a616e74696e65206661756c7420746f6c6572616e6365","coinbase":"0x0000000000000000000000000000000000000000","alloc":{"03ee8c85944b16dfa517cb0ddefe123c7341a534":{"balance":"0x446c3b15f9926687d2c40534fdb564000000000000"},"35d56a7515e824be4122f033d60063d035573a0c":{"balance":"0x446c3b15f9926687d2c40534fdb564000000000000"},"47a847fbdf801154253593851ac9a2e775323534":{"balance":"0x446c3b15f9926687d2c40534fdb564000000000000"},"c25d04978fd86ee604feb88f3c635d555eb6d42d":{"balance":"0x446c3b15f9926687d2c40534fdb564000000000000"}},"number":"0x0","gasUsed":"0x0","parentHash":"0x0000000000000000000000000000000000000000000000000000000000000000"}' > /eth/genesis.json
 echo '["enode://6204d2b6d844adf9dd23f47027b29b1e39b08c70b8ec05f82a8037f1676c058fe80035b42f32c649cc47347889abfe7732139b9f3f243ea91f990d2d72bb87bd@172.16.239.10:30303?discport=0","enode://a573feff0859205b566385aaf85f4c858dfe4ebb07ec862a2d03e117b3e39d8220aaf1d58750440ad844ddcb623f6becc9ba07fc27db4d30cdf689f15a9b1462@172.16.239.11:30303?discport=0","enode://76b750a2a0c92d2411e4793c714a85cf01e527c7a77f70548e7f363feaf8320039cd0f2eb48235c022d39df44ec06c96060f5c25caeec8a1960a356ebd5473a1@172.16.239.12:30303?discport=0","enode://f53fff2c7ed693b627d4389b92b6d94a11b91f167193a5d31320a2b35fb752f79b3aed7dcc61961bc00b397fdf8729eb797a0b28d6c538d51232164432b67f80@172.16.239.13:30303?discport=0"]' > /eth/geth/static-nodes.json
 geth --datadir "/eth" init "/eth/genesis.json"
@@ -12,7 +75,6 @@ test ! -z "${cache_gc}" && CACHE_GC_OPT="--cache.gc ${cache_gc}"
 GETH_CMD="geth \
 --datadir /eth \
 --identity ${identity} \
---nodekeyhex ${nodekeyhex} \
 --port 30303 \
 --networkid 2017 \
 --nat any \
@@ -31,6 +93,10 @@ ${METRICS_OPT} \
 --syncmode full \
 --miner.gastarget 800000000 \
 ${CACHE_OPT} \
+${CONFIG_OPT} \
+${NODEKEY_OPT} \
+${NODEKEY_SOURCE_OPT} \
+${NODEKEY_DECRYPTION_OPT} \
 ${CACHE_GC_OPT}"
 
 ash -c "nohup ${GETH_CMD//\*/\\\*} > /dev/stdout 2>&1 &"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ibet-network-tools"
-version = "0.1.0"
+version = "2.8"
 description = "Development tooling for ibet-Network"
 authors = ["BOOSTRY Co., Ltd. <dev@boostry.co.jp>"]
 

--- a/test-network/README.md
+++ b/test-network/README.md
@@ -44,6 +44,7 @@ Node key settings are also configurable through environment variables.
 * `nodekey_aws_kms_encryption_algorithm` Optional KMS encryption algorithm override, such as `RSAES_OAEP_SHA_256`  
 
 When `nodekey` or `nodekeyhex` is specified, the legacy configuration takes precedence and no additional AWS configuration is required.
+Validator nodes must set one of `nodekey`, `nodekeyhex`, or `nodekeysource` explicitly.
 
 ## 2. Start/Stop Validator node
 

--- a/test-network/README.md
+++ b/test-network/README.md
@@ -38,8 +38,8 @@ Node key settings are also configurable through environment variables.
 * `nodekeysource` Node key source (`file` or `aws-sm`)  
 * `nodekeydecryption` Node key decryption (`none` or `aws-kms`)  
 * `nodekey_aws_secret_name` AWS Secrets Manager secret name or ARN  
-* `nodekey_aws_secret_version_id` Optional AWS secret version ID  
-* `nodekey_aws_secret_version_stage` Optional AWS secret version stage, such as `AWSCURRENT`  
+* `nodekey_aws_secret_version_id` AWS secret version ID. When `nodekeysource=aws-sm`, this is required if `nodekey_aws_secret_version_stage` is not set.  
+* `nodekey_aws_secret_version_stage` AWS secret version stage, such as `AWSCURRENT`. When `nodekeysource=aws-sm`, this is required if `nodekey_aws_secret_version_id` is not set. Exactly one of `nodekey_aws_secret_version_id` or `nodekey_aws_secret_version_stage` must be specified when `nodekeysource=aws-sm`.  
 * `nodekey_aws_kms_key_id` AWS KMS key ID or alias, required when `nodekeydecryption=aws-kms`  
 * `nodekey_aws_kms_encryption_algorithm` Optional KMS encryption algorithm override, such as `RSAES_OAEP_SHA_256`  
 

--- a/test-network/README.md
+++ b/test-network/README.md
@@ -31,6 +31,20 @@ Common to all three types of nodes, you need to set the following environment va
 * `rpcvhosts` Comma separated list of virtual hostnames from which to accept requests (default: "localhost")  
 * `maxpeers` Maximum number of network peers (network disabled if set to 0) (default: 50)  
 
+Node key settings are also configurable through environment variables.
+
+* `nodekey` Path to the legacy node key file inside the container  
+* `nodekeyhex` Legacy node key as hex string  
+* `nodekeysource` Node key source (`file` or `aws-sm`)  
+* `nodekeydecryption` Node key decryption (`none` or `aws-kms`)  
+* `nodekey_aws_secret_name` AWS Secrets Manager secret name or ARN  
+* `nodekey_aws_secret_version_id` Optional AWS secret version ID  
+* `nodekey_aws_secret_version_stage` Optional AWS secret version stage, such as `AWSCURRENT`  
+* `nodekey_aws_kms_key_id` AWS KMS key ID or alias, required when `nodekeydecryption=aws-kms`  
+* `nodekey_aws_kms_encryption_algorithm` Optional KMS encryption algorithm override, such as `RSAES_OAEP_SHA_256`  
+
+When `nodekey` or `nodekeyhex` is specified, the legacy configuration takes precedence and no additional AWS configuration is required.
+
 ## 2. Start/Stop Validator node
 
 ### Set up
@@ -63,6 +77,18 @@ Finally, start the node as follows.
 ```
 $ docker run -d --name validator -e PRIVATE_CONFIG=ignore -e nodekeyhex={nodekey} -v {mount_directory}:/eth \
     ghcr.io/boostryjp/ibet-testnet/validator:{version} run.sh 
+```
+
+To load the validator node key from AWS Secrets Manager instead, start it as follows.
+```
+$ docker run -d --name validator -e PRIVATE_CONFIG=ignore \
+    -e nodekeysource=aws-sm \
+    -e nodekeydecryption=aws-kms \
+    -e nodekey_aws_secret_name={secret_name_or_arn} \
+    -e nodekey_aws_secret_version_stage=AWSCURRENT \
+    -e nodekey_aws_kms_key_id={kms_key_id_or_alias} \
+    -v {mount_directory}:/eth \
+    ghcr.io/boostryjp/ibet-testnet/validator:{version} run.sh
 ```
 
 ### Stop validator node 
@@ -110,6 +136,8 @@ Finally, start the node as follows.
 $ docker run -d --name general -e PRIVATE_CONFIG=ignore -v {mount_direcotry}:/eth \
     ghcr.io/boostryjp/ibet-testnet/general:{version} run.sh 
 ```
+
+The same AWS node key settings can be used for Bridge and General nodes as well.
 
 ### Stop node 
 When stopping a node, simply stop the container.

--- a/test-network/general/run.sh
+++ b/test-network/general/run.sh
@@ -1,6 +1,69 @@
 #!/bin/ash
 mkdir -p /eth/geth
 
+escape_toml_string() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+setup_nodekey_options() {
+  NODEKEY_SOURCE="${nodekeysource:-file}"
+  NODEKEY_DECRYPTION="${nodekeydecryption:-none}"
+
+  if [ -n "${nodekey}" ]; then
+    NODEKEY_OPT="--nodekey ${nodekey}"
+    return 0
+  fi
+  if [ -n "${nodekeyhex}" ]; then
+    NODEKEY_OPT="--nodekeyhex ${nodekeyhex}"
+    return 0
+  fi
+
+  if [ "${NODEKEY_SOURCE}" = "aws-sm" ]; then
+    if [ -z "${nodekey_aws_secret_name}" ]; then
+      echo "$0: nodekey_aws_secret_name is required when nodekeysource=aws-sm." >&2
+      return 1
+    fi
+    if [ -n "${nodekey_aws_secret_version_id}" ] && [ -n "${nodekey_aws_secret_version_stage}" ]; then
+      echo "$0: nodekey_aws_secret_version_id and nodekey_aws_secret_version_stage are mutually exclusive." >&2
+      return 1
+    fi
+    if [ -z "${nodekey_aws_secret_version_id}" ] && [ -z "${nodekey_aws_secret_version_stage}" ]; then
+      echo "$0: either nodekey_aws_secret_version_id or nodekey_aws_secret_version_stage is required when nodekeysource=aws-sm." >&2
+      return 1
+    fi
+    if [ "${NODEKEY_DECRYPTION}" = "aws-kms" ] && [ -z "${nodekey_aws_kms_key_id}" ]; then
+      echo "$0: nodekey_aws_kms_key_id is required when nodekeydecryption=aws-kms." >&2
+      return 1
+    fi
+
+    CONFIG_FILE="/eth/config.toml"
+    {
+      printf '[Node.P2P.NodeKey.ConfigAws]\n'
+      printf 'SecretName = "%s"\n' "$(escape_toml_string "${nodekey_aws_secret_name}")"
+      if [ -n "${nodekey_aws_secret_version_id}" ]; then
+        printf 'SecretVersionId = "%s"\n' "$(escape_toml_string "${nodekey_aws_secret_version_id}")"
+      fi
+      if [ -n "${nodekey_aws_secret_version_stage}" ]; then
+        printf 'SecretVersionStage = "%s"\n' "$(escape_toml_string "${nodekey_aws_secret_version_stage}")"
+      fi
+      if [ -n "${nodekey_aws_kms_key_id}" ]; then
+        printf 'KmsKeyId = "%s"\n' "$(escape_toml_string "${nodekey_aws_kms_key_id}")"
+      fi
+      if [ -n "${nodekey_aws_kms_encryption_algorithm}" ]; then
+        printf 'KmsEncryptionAlgorithm = "%s"\n' "$(escape_toml_string "${nodekey_aws_kms_encryption_algorithm}")"
+      fi
+    } > "${CONFIG_FILE}"
+    CONFIG_OPT="--config ${CONFIG_FILE}"
+  fi
+
+  if [ -n "${nodekeysource}" ] || [ -n "${nodekeydecryption}" ] || [ "${NODEKEY_SOURCE}" = "aws-sm" ]; then
+    NODEKEY_SOURCE_OPT="--nodekeysource ${NODEKEY_SOURCE}"
+    NODEKEY_DECRYPTION_OPT="--nodekeydecryption ${NODEKEY_DECRYPTION}"
+  fi
+}
+
+setup_nodekey_options || exit 1
+
 test ! -z "${rpccorsdomain}" && CORS_OPT="--http.corsdomain ${rpccorsdomain}"
 test ! -z "${rpcvhosts}" && VHOST_OPT="--http.vhosts ${rpcvhosts}"
 test ! -z "${maxpeers}" && PEERS_OPT="--maxpeers ${maxpeers}"
@@ -28,6 +91,10 @@ ${VHOST_OPT} \
 ${PEERS_OPT} \
 ${SYNCMODE_OPT} \
 ${CACHE_OPT} \
+${CONFIG_OPT} \
+${NODEKEY_OPT} \
+${NODEKEY_SOURCE_OPT} \
+${NODEKEY_DECRYPTION_OPT} \
 ${CACHE_GC_OPT}"
 
 if [ -z "${BLOCK_SYNC_MONITORING_DISABLED}" ] || [ "${BLOCK_SYNC_MONITORING_DISABLED}" -ne 1 ]; then

--- a/test-network/validator/run.sh
+++ b/test-network/validator/run.sh
@@ -1,6 +1,69 @@
 #!/bin/ash
 mkdir -p /eth/geth
 
+escape_toml_string() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+setup_nodekey_options() {
+  NODEKEY_SOURCE="${nodekeysource:-file}"
+  NODEKEY_DECRYPTION="${nodekeydecryption:-none}"
+
+  if [ -n "${nodekey}" ]; then
+    NODEKEY_OPT="--nodekey ${nodekey}"
+    return 0
+  fi
+  if [ -n "${nodekeyhex}" ]; then
+    NODEKEY_OPT="--nodekeyhex ${nodekeyhex}"
+    return 0
+  fi
+
+  if [ "${NODEKEY_SOURCE}" = "aws-sm" ]; then
+    if [ -z "${nodekey_aws_secret_name}" ]; then
+      echo "$0: nodekey_aws_secret_name is required when nodekeysource=aws-sm." >&2
+      return 1
+    fi
+    if [ -n "${nodekey_aws_secret_version_id}" ] && [ -n "${nodekey_aws_secret_version_stage}" ]; then
+      echo "$0: nodekey_aws_secret_version_id and nodekey_aws_secret_version_stage are mutually exclusive." >&2
+      return 1
+    fi
+    if [ -z "${nodekey_aws_secret_version_id}" ] && [ -z "${nodekey_aws_secret_version_stage}" ]; then
+      echo "$0: either nodekey_aws_secret_version_id or nodekey_aws_secret_version_stage is required when nodekeysource=aws-sm." >&2
+      return 1
+    fi
+    if [ "${NODEKEY_DECRYPTION}" = "aws-kms" ] && [ -z "${nodekey_aws_kms_key_id}" ]; then
+      echo "$0: nodekey_aws_kms_key_id is required when nodekeydecryption=aws-kms." >&2
+      return 1
+    fi
+
+    CONFIG_FILE="/eth/config.toml"
+    {
+      printf '[Node.P2P.NodeKey.ConfigAws]\n'
+      printf 'SecretName = "%s"\n' "$(escape_toml_string "${nodekey_aws_secret_name}")"
+      if [ -n "${nodekey_aws_secret_version_id}" ]; then
+        printf 'SecretVersionId = "%s"\n' "$(escape_toml_string "${nodekey_aws_secret_version_id}")"
+      fi
+      if [ -n "${nodekey_aws_secret_version_stage}" ]; then
+        printf 'SecretVersionStage = "%s"\n' "$(escape_toml_string "${nodekey_aws_secret_version_stage}")"
+      fi
+      if [ -n "${nodekey_aws_kms_key_id}" ]; then
+        printf 'KmsKeyId = "%s"\n' "$(escape_toml_string "${nodekey_aws_kms_key_id}")"
+      fi
+      if [ -n "${nodekey_aws_kms_encryption_algorithm}" ]; then
+        printf 'KmsEncryptionAlgorithm = "%s"\n' "$(escape_toml_string "${nodekey_aws_kms_encryption_algorithm}")"
+      fi
+    } > "${CONFIG_FILE}"
+    CONFIG_OPT="--config ${CONFIG_FILE}"
+  fi
+
+  if [ -n "${nodekeysource}" ] || [ -n "${nodekeydecryption}" ] || [ "${NODEKEY_SOURCE}" = "aws-sm" ]; then
+    NODEKEY_SOURCE_OPT="--nodekeysource ${NODEKEY_SOURCE}"
+    NODEKEY_DECRYPTION_OPT="--nodekeydecryption ${NODEKEY_DECRYPTION}"
+  fi
+}
+
+setup_nodekey_options || exit 1
+
 test ! -z "${rpccorsdomain}" && CORS_OPT="--http.corsdomain ${rpccorsdomain}"
 test ! -z "${rpcvhosts}" && VHOST_OPT="--http.vhosts ${rpcvhosts}"
 test ! -z "${maxpeers}" && PEERS_OPT="--maxpeers ${maxpeers}"
@@ -20,7 +83,6 @@ ${IDENTITY_OPT} \
 ${VHOST_OPT} \
 --networkid 1500002 \
 --nat any \
---nodekeyhex $nodekeyhex \
 --mine \
 --syncmode full \
 --verbosity ${verbosity:-2} \
@@ -28,6 +90,10 @@ ${VHOST_OPT} \
 --miner.gastarget 800000000 \
 ${PEERS_OPT} \
 ${CACHE_OPT} \
+${CONFIG_OPT} \
+${NODEKEY_OPT} \
+${NODEKEY_SOURCE_OPT} \
+${NODEKEY_DECRYPTION_OPT} \
 ${CACHE_GC_OPT}"
 
 ash -c "nohup ${GETH_CMD//\*/\\\*} > /dev/stdout 2>&1 &"

--- a/test-network/validator/run.sh
+++ b/test-network/validator/run.sh
@@ -6,6 +6,11 @@ escape_toml_string() {
 }
 
 setup_nodekey_options() {
+  if [ -z "${nodekey}" ] && [ -z "${nodekeyhex}" ] && [ -z "${nodekeysource}" ]; then
+    echo "$0: validator nodes require nodekey, nodekeyhex, or nodekeysource to be set." >&2
+    return 1
+  fi
+
   NODEKEY_SOURCE="${nodekeysource:-file}"
   NODEKEY_DECRYPTION="${nodekeydecryption:-none}"
 

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ibet-Network tests"
-version = "2.7"
+version = "2.8"
 description = "E2E tests from python client to Quorum node containers"
 authors = ["BOOSTRY Co., Ltd. <dev@boostry.co.jp>"]
 


### PR DESCRIPTION
close #219 

This pull request introduces support for configuring node keys via AWS Secrets Manager and AWS KMS across all node types (Validator, General, Bridge) in the ibet-Network project.

**Node key management enhancements:**

* Added support in all node startup scripts (`run.sh` for Validator and General nodes in both `ibet-for-fin-network` and `local-network`) to load node keys from AWS Secrets Manager, optionally decrypting with AWS KMS. This includes robust environment variable parsing, error handling, and dynamic TOML config file generation.

**Documentation updates:**

* Expanded documentation in `ibet-for-fin-network/README.md` and `test-network/README.md` to describe the new node key environment variables and provide usage examples for AWS-based key management.
