### PR TITLE
chore(docker): update ibet-Core checkout to v2.8.0_beta1 in Dockerfiles and docker-compose

### DIFF
--- a/ibet-for-fin-network/general/Dockerfile
+++ b/ibet-for-fin-network/general/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/ibet-Core.git && \
     cd ibet-Core/ && \
-    git checkout v2.7.0
+    git checkout v2.8.0_beta1
 RUN cd ibet-Core/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/ibet-for-fin-network/validator/Dockerfile
+++ b/ibet-for-fin-network/validator/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/ibet-Core.git && \
     cd ibet-Core/ && \
-    git checkout v2.7.0
+    git checkout v2.8.0_beta1
 RUN cd ibet-Core/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/local-network/docker-compose.yml
+++ b/local-network/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   validator-0:
     hostname: validator-0
-    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.7.0
+    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.8.0_beta1
     volumes:
       - /home/ubuntu/quorum_data/v0:/eth
     environment:
@@ -28,7 +28,7 @@ services:
     restart: always
   validator-1:
     hostname: validator-1
-    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.7.0
+    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.8.0_beta1
     volumes:
       - /home/ubuntu/quorum_data/v1:/eth
     environment:
@@ -55,7 +55,7 @@ services:
     restart: always
   validator-2:
     hostname: validator-2
-    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.7.0
+    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.8.0_beta1
     volumes:
       - /home/ubuntu/quorum_data/v2:/eth
     environment:
@@ -82,7 +82,7 @@ services:
     restart: always
   validator-3:
     hostname: validator-3
-    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.7.0
+    image: ghcr.io/boostryjp/ibet-localnet/validator:v2.8.0_beta1
     volumes:
       - /home/ubuntu/quorum_data/v3:/eth
     environment:
@@ -109,7 +109,7 @@ services:
     restart: always
   general-0:
     hostname: general-0
-    image: ghcr.io/boostryjp/ibet-localnet/general:v2.7.0
+    image: ghcr.io/boostryjp/ibet-localnet/general:v2.8.0_beta1
     volumes:
       - /home/ubuntu/quorum_data/g0:/eth
     environment:

--- a/local-network/general/Dockerfile
+++ b/local-network/general/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/ibet-Core.git && \
     cd ibet-Core/ && \
-    git checkout v2.7.0
+    git checkout v2.8.0_beta1
 RUN cd ibet-Core/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/local-network/validator/Dockerfile
+++ b/local-network/validator/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/ibet-Core.git && \
     cd ibet-Core/ && \
-    git checkout v2.7.0
+    git checkout v2.8.0_beta1
 RUN cd ibet-Core/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/test-network/general/Dockerfile
+++ b/test-network/general/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/ibet-Core.git && \
     cd ibet-Core/ && \
-    git checkout v2.7.0
+    git checkout v2.8.0_beta1
 RUN cd ibet-Core/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \

--- a/test-network/validator/Dockerfile
+++ b/test-network/validator/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 RUN git clone https://github.com/BoostryJP/ibet-Core.git && \
     cd ibet-Core/ && \
-    git checkout v2.7.0
+    git checkout v2.8.0_beta1
 RUN cd ibet-Core/ && \
     make geth bootnode && \
     mv build/bin/geth /usr/local/bin && \


### PR DESCRIPTION
This pull request updates the ibet-Core and related Docker images used throughout the project from version `v2.7.0` to `v2.8.0_beta1`. The changes ensure that all Dockerfiles and the local network configuration reference the new beta version, aligning the build and runtime environments with the latest upstream release.

**Core version and image updates:**

* Updated the `git checkout` command in all `general` and `validator` Dockerfiles (`ibet-for-fin-network`, `local-network`, `test-network`) to use `v2.8.0_beta1` instead of `v2.7.0`. [[1]](diffhunk://#diff-f84c04ae7cc0185f918f9328ccd29d0e955c49fe4b03374f83525f2c1c051798L10-R10) [[2]](diffhunk://#diff-d1a06db141b86a22b51e031d57e36b61f28ed2fc1a28ca0851f5bc1d6148bd9aL10-R10) [[3]](diffhunk://#diff-b3c35a5c83aa8bee2fb473b062d29438b02d2587f207f6527bd337522d539d50L10-R10)
* Updated all validator and general service images in `local-network/docker-compose.yml` to use `ghcr.io/boostryjp/ibet-localnet/*:v2.8.0_beta1` instead of `v2.7.0`. [[1]](diffhunk://#diff-00057302f622d76b3e91dcc622703daf60ea07cef971260223329b0364b19e00L4-R4) [[2]](diffhunk://#diff-00057302f622d76b3e91dcc622703daf60ea07cef971260223329b0364b19e00L31-R31) [[3]](diffhunk://#diff-00057302f622d76b3e91dcc622703daf60ea07cef971260223329b0364b19e00L58-R58) [[4]](diffhunk://#diff-00057302f622d76b3e91dcc622703daf60ea07cef971260223329b0364b19e00L85-R85) [[5]](diffhunk://#diff-00057302f622d76b3e91dcc622703daf60ea07cef971260223329b0364b19e00L112-R112)

These updates keep the development and deployment environments consistent with the latest ibet-Core release and ensure compatibility with new features and fixes.