### PR TITLE
chore(docker): update Go version to 1.26.4 in multiple Dockerfiles

### DIFF
--- a/ibet-for-fin-network/general/Dockerfile
+++ b/ibet-for-fin-network/general/Dockerfile
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 WORKDIR /work
 

--- a/ibet-for-fin-network/validator/Dockerfile
+++ b/ibet-for-fin-network/validator/Dockerfile
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 WORKDIR /work
 

--- a/local-network/general/Dockerfile
+++ b/local-network/general/Dockerfile
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 WORKDIR /work
 

--- a/local-network/validator/Dockerfile
+++ b/local-network/validator/Dockerfile
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 WORKDIR /work
 

--- a/test-network/general/Dockerfile
+++ b/test-network/general/Dockerfile
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 WORKDIR /work
 

--- a/test-network/validator/Dockerfile
+++ b/test-network/validator/Dockerfile
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 WORKDIR /work
 


### PR DESCRIPTION
This pull request updates the Go base image version used in several Dockerfiles across the project. The main change is upgrading from `golang:1.25-alpine` to `golang:1.26.4-alpine` to ensure the latest Go features, improvements, and security patches are used.

**Docker base image upgrade:**

* Updated the Go builder image from `golang:1.25-alpine` to `golang:1.26.4-alpine` in the following Dockerfiles:
  - `ibet-for-fin-network/general/Dockerfile`
  - `ibet-for-fin-network/validator/Dockerfile`
  - `local-network/general/Dockerfile`
  - `local-network/validator/Dockerfile`
  - `test-network/general/Dockerfile`
  - `test-network/validator/Dockerfile`